### PR TITLE
Source node modules from content directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.16.3
+      - image: circleci/node:12.16.3
 
     working_directory: ~/repo
 

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -10,7 +10,7 @@ const EXTRACT_SOURCE = /\[source,(ts|js)\]/;
 const EXTRACT_DIRECTIVE = /^\/\/ verifier:(.*)$/;
 const TOP_HEADER = /^={1,3} (.*)$/;
 
-export function extractSamples(text: string, filename: string): PrefixedCodeSample[] {
+export function extractSamples(text: string, filename: string, sourceFile: string): PrefixedCodeSample[] {
   const samples = [];
   const lines = text.split('\n');
   let i = 0;
@@ -129,7 +129,7 @@ export function extractSamples(text: string, filename: string): PrefixedCodeSamp
             nodeModules,
             isTSX: nextIsTSX,
             checkJS: nextShouldCheckJs,
-            sourceFile: filename,
+            sourceFile,
             tsOptions: {...tsOptions},
           });
         }

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -10,7 +10,11 @@ const EXTRACT_SOURCE = /\[source,(ts|js)\]/;
 const EXTRACT_DIRECTIVE = /^\/\/ verifier:(.*)$/;
 const TOP_HEADER = /^={1,3} (.*)$/;
 
-export function extractSamples(text: string, filename: string, sourceFile: string): PrefixedCodeSample[] {
+export function extractSamples(
+  text: string,
+  filename: string,
+  sourceFile: string,
+): PrefixedCodeSample[] {
   const samples = [];
   const lines = text.split('\n');
   let i = 0;

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -129,6 +129,7 @@ export function extractSamples(text: string, filename: string): PrefixedCodeSamp
             nodeModules,
             isTSX: nextIsTSX,
             checkJS: nextShouldCheckJs,
+            sourceFile: filename,
             tsOptions: {...tsOptions},
           });
         }
@@ -214,6 +215,7 @@ export function applyPrefixes(
       nodeModules: sample.nodeModules,
       isTSX: sample.isTSX,
       checkJS: sample.checkJS,
+      sourceFile: sample.sourceFile,
       content,
     };
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ if (argv.replacements) {
   }
 }
 
+// TODO(danvk): prefer the tsconfig.json from asciidocs directory
 const unParsedConfig = ts.readConfigFile('tsconfig.json', ts.sys.readFile).config || {};
 const {options: tsOptions} = ts.parseJsonConfigFileContent(unParsedConfig, ts.sys, process.cwd());
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ async function processAsciidoc(path: string, fileNum: number, outOf: number) {
   startFile(path);
 
   const text = fs.readFileSync(path, 'utf-8');
-  const rawSamples = extractSamples(text, fileSlug(path));
+  const rawSamples = extractSamples(text, fileSlug(path), path);
   log(`Found ${rawSamples.length} code samples in ${path}`);
 
   for (const sample of rawSamples) {

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -99,6 +99,7 @@ describe('code-sample', () => {
     checkJS: false,
     sectionId: null,
     sectionHeader: null,
+    sourceFile: 'source.asciidoc',
   };
 
   const baseExtract = {

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -108,7 +108,7 @@ describe('code-sample', () => {
 
   describe('extractSamples', () => {
     test('basic', () => {
-      expect(extractSamples(ASCII_DOC1, 'doc1')).toEqual([
+      expect(extractSamples(ASCII_DOC1, 'doc1', 'source.asciidoc')).toEqual([
         {
           ...baseExtract,
           language: 'ts',
@@ -123,7 +123,7 @@ describe('code-sample', () => {
 
     test('no ID', () => {
       // Only the TypeScript sample gets extracted (may want to revisit this).
-      expect(extractSamples(ASCIIDOC_NO_ID, 'noid')).toEqual([
+      expect(extractSamples(ASCIIDOC_NO_ID, 'noid', 'source.asciidoc')).toEqual([
         {
           ...baseExtract,
           language: 'ts',
@@ -134,33 +134,37 @@ describe('code-sample', () => {
     });
 
     test('prepend directive', () => {
-      expect(applyPrefixes(extractSamples(ASCIIDOC_PREPEND, 'prepend'))).toEqual([
-        {
-          ...baseSample,
-          language: 'ts',
-          id: 'prefix',
-          content: `type AB = 'a' | 'b';`,
-        },
-        {
-          ...baseSample,
-          language: 'ts',
-          id: 'combined',
-          content: dedent`
+      expect(applyPrefixes(extractSamples(ASCIIDOC_PREPEND, 'prepend', 'source.asciidoc'))).toEqual(
+        [
+          {
+            ...baseSample,
+            language: 'ts',
+            id: 'prefix',
+            content: `type AB = 'a' | 'b';`,
+          },
+          {
+            ...baseSample,
+            language: 'ts',
+            id: 'combined',
+            content: dedent`
             type AB = 'a' | 'b';
             const a: AB = 'a';`,
-        },
-        {
-          ...baseSample,
-          language: 'ts',
-          id: 'final',
-          content: `const a: AB = 'a';`,
-        },
-      ]);
+          },
+          {
+            ...baseSample,
+            language: 'ts',
+            id: 'final',
+            content: `const a: AB = 'a';`,
+          },
+        ],
+      );
     });
   });
 
   test('multiple prepend directives', () => {
-    expect(applyPrefixes(extractSamples(ASCIIDOC_PREPEND_MULTIPLE, 'mpd'))).toEqual([
+    expect(
+      applyPrefixes(extractSamples(ASCIIDOC_PREPEND_MULTIPLE, 'mpd', 'source.asciidoc')),
+    ).toEqual([
       {
         ...baseSample,
         language: 'ts',
@@ -209,6 +213,7 @@ describe('code-sample', () => {
     ----
     `,
           'prepend-subset',
+          'source.asciidoc',
         ),
       ),
     ).toEqual([
@@ -256,6 +261,7 @@ describe('code-sample', () => {
     ----
     `,
           'prepend-subset',
+          'source.asciidoc',
         ),
       ),
     ).toEqual([
@@ -281,7 +287,7 @@ describe('code-sample', () => {
   });
 
   test('skip directive', () => {
-    expect(extractSamples(ASCIIDOC_SKIP, 'skip')).toEqual([]);
+    expect(extractSamples(ASCIIDOC_SKIP, 'skip', 'source.asciidoc')).toEqual([]);
   });
 
   test('tsconfig directive', () => {
@@ -306,6 +312,7 @@ describe('code-sample', () => {
 
     `,
         'tsconfig',
+        'source.asciidoc',
       ),
     ).toEqual([
       {
@@ -348,6 +355,7 @@ describe('code-sample', () => {
     ----
     `,
         'prepend-with-id',
+        'source.asciidoc',
       ).slice(-1),
     ).toEqual([
       {
@@ -372,6 +380,7 @@ describe('code-sample', () => {
     ----
     `,
         'tsx-example',
+        'source.asciidoc',
       ).slice(-1),
     ).toEqual([
       {
@@ -403,6 +412,7 @@ describe('code-sample', () => {
       ----
     `,
         'header-reset',
+        'source.asciidoc',
       ),
     ).toEqual([
       {
@@ -439,6 +449,7 @@ describe('code-sample', () => {
       ----
     `,
         'header-reset',
+        'source.asciidoc',
       ),
     ).toEqual([
       {
@@ -482,6 +493,7 @@ describe('code-sample', () => {
       ----
       `,
           'header-reset',
+          'source.asciidoc',
         ),
       ),
     ).toEqual([

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface CodeSample {
   isTSX: boolean;
   checkJS: boolean;
   tsOptions: CompilerOptions;
+  sourceFile: string;
   nodeModules: readonly string[];
   output?: SampleOutput;
 }


### PR DESCRIPTION
The trick was to set `typeRoots`. Not sure if this works for runtime node modules.

Closes #6 