### PR TITLE
Require multiline type assertions to be aligned

### DIFF
--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -20,6 +20,8 @@ Array [
 ]
 `;
 
+exports[`extractSamples snapshot: multilinetype 1`] = `Array []`;
+
 exports[`extractSamples snapshot: noid 1`] = `
 Array [
   Object {

--- a/src/test/__snapshots__/markdown.test.ts.snap
+++ b/src/test/__snapshots__/markdown.test.ts.snap
@@ -20,6 +20,45 @@ Array [
 ]
 `;
 
+exports[`markdown should match snapshots: multilinetype 1`] = `
+Array [
+  Object {
+    "checkJS": false,
+    "content": "const o = {x: 1, y: 2};
+// type is {
+//   x: number;
+//   y: number;
+// }",
+    "id": "multilinetype-3",
+    "isTSX": false,
+    "language": "ts",
+    "nodeModules": Array [],
+    "prefixes": Array [],
+    "sectionHeader": null,
+    "sectionId": null,
+    "sourceFile": "multilinetype.md",
+    "tsOptions": Object {},
+  },
+  Object {
+    "checkJS": false,
+    "content": "function addWithExtras(a: number, b: number) {
+  const c = a + b;  // type is number
+  // ...
+  return c;
+}",
+    "id": "multilinetype-13",
+    "isTSX": false,
+    "language": "ts",
+    "nodeModules": Array [],
+    "prefixes": Array [],
+    "sectionHeader": null,
+    "sectionId": null,
+    "sourceFile": "multilinetype.md",
+    "tsOptions": Object {},
+  },
+]
+`;
+
 exports[`markdown should match snapshots: noid 1`] = `
 Array [
   Object {

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -80,7 +80,7 @@ describe('extractSamples', () => {
     const dir = './src/test/inputs';
 
     // TODO(danvk): use a glob here
-    const inputs = ['doc1', 'noid', 'prepend', 'prepend-multiple', 'skip'];
+    const inputs = ['doc1', 'noid', 'prepend', 'prepend-multiple', 'skip', 'multilinetype'];
 
     for (const input of inputs) {
       expect(

--- a/src/test/inputs/multilinetype.asciidoc
+++ b/src/test/inputs/multilinetype.asciidoc
@@ -1,0 +1,19 @@
+This example has a multiline type assertion:
+
+```ts
+const o = {x: 1, y: 2};
+// type is {
+//   x: number;
+//   y: number;
+// }
+```
+
+Whereas this is not a multiline assertion:
+
+```ts
+function addWithExtras(a: number, b: number) {
+  const c = a + b;  // type is number
+  // ...
+  return c;
+}
+```

--- a/src/test/inputs/multilinetype.md
+++ b/src/test/inputs/multilinetype.md
@@ -1,0 +1,19 @@
+This example has a multiline type assertion:
+
+```ts
+const o = {x: 1, y: 2};
+// type is {
+//   x: number;
+//   y: number;
+// }
+```
+
+Whereas this is not a multiline assertion:
+
+```ts
+function addWithExtras(a: number, b: number) {
+  const c = a + b;  // type is number
+  // ...
+  return c;
+}
+```

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -7,7 +7,7 @@ describe('markdown', () => {
     const dir = './src/test/inputs';
 
     // TODO(danvk): use a glob here
-    const inputs = ['doc1', 'noid', 'prepend', 'prepend-multiple', 'skip'];
+    const inputs = ['doc1', 'noid', 'prepend', 'prepend-multiple', 'skip', 'multilinetype'];
 
     for (const input of inputs) {
       expect(

--- a/src/test/ts-checker.test.ts
+++ b/src/test/ts-checker.test.ts
@@ -207,6 +207,30 @@ describe('ts-checker', () => {
         type: '(elementId: string) => HTMLElement | null',
       },
     ]);
+
+    expect(
+      getAssertions(dedent`
+      const o = {x: 1, y: 2};
+      // type is {
+      //   x: number;
+      //   y: number;
+      // }
+      function addWithExtras(a: number, b: number) {
+        const c = a + b;  // type is number
+        // ...
+        return c;
+      }
+      `),
+    ).toEqual([
+      {
+        line: 0,
+        type: '{ x: number; y: number; }',
+      },
+      {
+        line: 6,
+        type: 'number',
+      },
+    ]);
   });
 
   describe('checkTypeAssertions', () => {

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -161,7 +161,9 @@ export function extractTypeAssertions(
     }
 
     const pos = scanner.getTokenPos();
-    let {line, character} = source.getLineAndCharacterOfPosition(pos);
+    const lineChar = source.getLineAndCharacterOfPosition(pos);
+    let {line} = lineChar;
+    const {character} = lineChar;
 
     if (token === ts.SyntaxKind.SingleLineCommentTrivia) {
       const commentText = scanner.getTokenText();


### PR DESCRIPTION
There were some errors that popped up in _Effective TypeScript_ after #8. They looked like this:

```ts
getRanges() {
  for (const r of this.indices) {
    const low = r[0];  // Type is any
    const high = r[1];  // Type is any
    // ...
  }
}
```