### PR TITLE
Add an on-disk cache

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports =  {
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
   }
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
+    "fast-json-stable-stringify": "^2.1.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "literate-ts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Code samples that scale",
   "main": "dist/index.js",
   "repository": "https://github.com/danvk/literate-ts.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "literate-ts",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "description": "Code samples that scale",
   "main": "dist/index.js",
   "repository": "https://github.com/danvk/literate-ts.git",

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -6,6 +6,7 @@ import {fail} from './test-tracker';
 import {extractAsciidocSamples} from './asciidoc';
 import {extractMarkdownSamples} from './markdown';
 import {generateIdMetadata} from './metadata';
+import {dedent} from './utils';
 
 export interface Processor {
   setLineNum(line: number): void;
@@ -167,12 +168,18 @@ export function checkSource(sample: CodeSample, source: string) {
   // Strip out code behind HIDE..END markers
   const strippedSource = stripSource(source);
   if (sample.content.trim() !== strippedSource.trim()) {
-    fail('Inline sample does not match sample in source file', sample);
-    log('Inline sample:');
-    log(sample.content.trim());
-    log('----');
-    log('Stripped source file sample:');
-    log(strippedSource.trim() + '\n');
+    fail(
+      `
+Inline sample for ${sample.id} does not match sample in source file
+Inline sample:
+${sample.content.trim()}
+----
+Stripped source file sample:
+${strippedSource.trim()}
+----
+      `.trimStart(),
+      sample,
+    );
     return false;
   }
   return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,12 +22,7 @@ import {
 import {checkTs, ConfigBundle} from './ts-checker';
 import {CodeSample} from './types';
 import {getTempDir, writeTempFile, fileSlug} from './utils';
-
-const packagePath = path.join(
-  __dirname,
-  // The path to package.json is slightly different when you run via ts-node
-  __dirname.includes('dist') ? '../../package.json' : '../package.json',
-);
+import {VERSION} from './version';
 
 const argv = yargs
   .strict()
@@ -52,10 +47,7 @@ const argv = yargs
   })
   .version(
     'version',
-    [
-      `literate-ts version: ${require(packagePath).version}`,
-      `TypeScript version: ${ts.version}`,
-    ].join('\n'),
+    [`literate-ts version: ${VERSION}`, `TypeScript version: ${ts.version}`].join('\n'),
   )
   .parse();
 
@@ -126,7 +118,10 @@ async function checkSample(sample: CodeSample, idToSample: {[id: string]: CodeSa
   startSample(sample);
 
   if (language === 'ts' || (language === 'js' && sample.checkJS)) {
-    await checkTs(sample, id + '-output' in idToSample, typeScriptBundle);
+    const result = await checkTs(sample, id + '-output' in idToSample, typeScriptBundle);
+    if (result.output !== undefined) {
+      sample.output = result.output;
+    }
   } else if (language === 'js') {
     // Run the sample through Node and record the output.
     const path = writeTempFile(id + '.js', content);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import {
 } from './test-tracker';
 import {checkTs, ConfigBundle} from './ts-checker';
 import {CodeSample} from './types';
-import {getTempDir, writeTempFile, fileSlug} from './utils';
+import {writeTempFile, fileSlug} from './utils';
 import {VERSION} from './version';
 
 const argv = yargs
@@ -85,7 +85,7 @@ function checkOutput(expectedOutput: string, input: CodeSample) {
   }
 
   // Remove stack traces from output
-  const tmpDir = getTempDir();
+  const tmpDir = path.dirname(actualOutput.path);
   const checkOutput = (actualOutput.stderr + actualOutput.stdout)
     .split('\n')
     .filter(line => !line.startsWith('    at ')) // prune stack traces to one line
@@ -109,6 +109,8 @@ function checkOutput(expectedOutput: string, input: CodeSample) {
     log('Actual:');
     log(checkOutput);
     log('----');
+  } else {
+    log('Actual output matched expected.');
   }
 }
 
@@ -120,6 +122,7 @@ async function checkSample(sample: CodeSample, idToSample: {[id: string]: CodeSa
   if (language === 'ts' || (language === 'js' && sample.checkJS)) {
     const result = await checkTs(sample, id + '-output' in idToSample, typeScriptBundle);
     if (result.output !== undefined) {
+      console.log('saved output for', id);
       sample.output = result.output;
     }
   } else if (language === 'js') {
@@ -142,7 +145,6 @@ async function checkSample(sample: CodeSample, idToSample: {[id: string]: CodeSa
       fail(`No paired input: #${inputId}`);
     } else {
       checkOutput(content, input);
-      log('Actual output matched expected.');
     }
   }
   finishSample();

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,6 @@ async function checkSample(sample: CodeSample, idToSample: {[id: string]: CodeSa
   if (language === 'ts' || (language === 'js' && sample.checkJS)) {
     const result = await checkTs(sample, id + '-output' in idToSample, typeScriptBundle);
     if (result.output !== undefined) {
-      console.log('saved output for', id);
       sample.output = result.output;
     }
   } else if (language === 'js') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,10 @@ const argv = yargs
       type: 'boolean',
       description: 'Log to stderr in addition to a log file',
     },
+    nocache: {
+      type: 'boolean',
+      description: `Don't read previous results from cache.`,
+    },
   })
   .version(
     'version',
@@ -120,7 +124,9 @@ async function checkSample(sample: CodeSample, idToSample: {[id: string]: CodeSa
   startSample(sample);
 
   if (language === 'ts' || (language === 'js' && sample.checkJS)) {
-    const result = await checkTs(sample, id + '-output' in idToSample, typeScriptBundle);
+    const result = await checkTs(sample, id + '-output' in idToSample, typeScriptBundle, {
+      skipCache: !!argv.nocache,
+    });
     if (result.output !== undefined) {
       sample.output = result.output;
     }

--- a/src/node-runner.ts
+++ b/src/node-runner.ts
@@ -7,17 +7,18 @@ export interface ExecErrorType {
   code: number;
   stdout: string;
   stderr: string;
+  path: string;
 }
 
 /** Run a JavaScript program through Node.js. Returns the output. */
 export async function runNode(path: string): Promise<ExecErrorType> {
   try {
     const {stdout, stderr} = await util.promisify(exec)(`node ${path}`);
-    return {code: 0, stderr, stdout};
+    return {code: 0, stderr, stdout, path};
   } catch (eIn) {
     const e = eIn as ExecErrorType;
     const {code, stderr, stdout} = e;
     log(`Node exited with error ${e.code} on ${path}`);
-    return {code, stderr, stdout};
+    return {code, stderr, stdout, path};
   }
 }

--- a/src/test-tracker.ts
+++ b/src/test-tracker.ts
@@ -39,13 +39,17 @@ export function fail(message: string, sample?: CodeSample) {
   }
   lastFailReason = message;
 
-  const fullMessage = `💥 ${currentSample?.descriptor}: ${message}`;
+  let id = sample?.descriptor;
+  if (sample?.id !== sample?.descriptor) {
+    id += ` (${sample?.id})`;
+  }
+  const fullMessage = `💥 ${id}: ${message}`;
   if (!isLoggingToStderr()) {
     console.error('\n' + fullMessage);
   }
   log(fullMessage);
   if (!(global as any).__TEST__) {
-    results[currentFile][currentSample!.descriptor]++;
+    results[currentFile][sample!.descriptor]++;
   }
 }
 

--- a/src/test-tracker.ts
+++ b/src/test-tracker.ts
@@ -39,11 +39,7 @@ export function fail(message: string, sample?: CodeSample) {
   }
   lastFailReason = message;
 
-  let id = sample?.descriptor;
-  if (sample?.id !== sample?.descriptor) {
-    id += ` (${sample?.id})`;
-  }
-  const fullMessage = `💥 ${id}: ${message}`;
+  const fullMessage = `💥 ${sample?.descriptor}: ${message}`;
   if (!isLoggingToStderr()) {
     console.error('\n' + fullMessage);
   }

--- a/src/test-tracker.ts
+++ b/src/test-tracker.ts
@@ -29,12 +29,15 @@ export function finishSample() {
   const elapsedMs = Date.now() - sampleStartMs;
   log(`\nEND #${currentSample!.descriptor} (${elapsedMs} ms)\n`);
   currentSample = undefined;
+  lastFailReason = null;
 }
 
+let lastFailReason: string | null = null;
 export function fail(message: string, sample?: CodeSample) {
   if (sample === undefined) {
     sample = currentSample;
   }
+  lastFailReason = message;
 
   const fullMessage = `💥 ${currentSample?.descriptor}: ${message}`;
   if (!isLoggingToStderr()) {
@@ -44,6 +47,10 @@ export function fail(message: string, sample?: CodeSample) {
   if (!(global as any).__TEST__) {
     results[currentFile][currentSample!.descriptor]++;
   }
+}
+
+export function getLastFailReason(): string | null {
+  return lastFailReason;
 }
 
 export function getTestResults() {

--- a/src/test/ts-checker.test.ts
+++ b/src/test/ts-checker.test.ts
@@ -9,6 +9,7 @@ import {
   checkTypeAssertions,
   getLanguageServiceHost,
   matchModuloWhitespace,
+  sortUnions,
 } from '../ts-checker';
 import {dedent} from '../utils';
 
@@ -504,6 +505,27 @@ describe('ts-checker', () => {
 
     it('should flag different types', () => {
       expect(matchModuloWhitespace('string', 'number')).toBe(false);
+    });
+
+    it('should allow differing orders for unions', () => {
+      expect(matchModuloWhitespace('B | A', 'A|B')).toBe(true);
+    });
+  });
+
+  describe('sortUnions', () => {
+    it('should sort unions', () => {
+      expect(sortUnions('C | B | A')).toEqual('A | B | C');
+      expect(sortUnions('string | Date | number')).toEqual('Date | number | string');
+    });
+
+    it('should ignore unions inside types', () => {
+      expect(sortUnions(`{x:C|B|A}`)).toEqual(`{x:C|B|A}`);
+      expect(sortUnions(`(x:C|B|A)=>void`)).toEqual(`(x:C|B|A)=>void`);
+      expect(sortUnions(`Partial<C|B|A>`)).toEqual(`Partial<C|B|A>`);
+    });
+
+    it('should sort unions of complex types', () => {
+      expect(sortUnions(`{foo:B|A} | {bar:C|D}`)).toEqual(`{bar:C|D} | {foo:B|A}`);
     });
   });
 });

--- a/src/test/ts-checker.test.ts
+++ b/src/test/ts-checker.test.ts
@@ -504,11 +504,11 @@ describe('ts-checker', () => {
     });
 
     it('should flag different types', () => {
-      expect(matchModuloWhitespace('string', 'number')).toBe(false);
+      expect(matchModuloWhitespace('const x: string', 'const x: number')).toBe(false);
     });
 
     it('should allow differing orders for unions', () => {
-      expect(matchModuloWhitespace('B | A', 'A|B')).toBe(true);
+      expect(matchModuloWhitespace('const ab: B | A', 'const ab: A|B')).toBe(true);
     });
   });
 

--- a/src/test/ts-checker.test.ts
+++ b/src/test/ts-checker.test.ts
@@ -8,6 +8,7 @@ import {
   extractTypeAssertions,
   checkTypeAssertions,
   getLanguageServiceHost,
+  matchModuloWhitespace,
 } from '../ts-checker';
 import {dedent} from '../utils';
 
@@ -490,5 +491,19 @@ describe('ts-checker', () => {
     //     foo  // type is number
     //   `)).toBe(true);
     // });
+  });
+
+  describe('matchModuloWhitespace', () => {
+    it('should normalize whitespace around parens', () => {
+      const expected =
+        'type T = <T extends object, K extends keyof T>( obj: T, ...keys: K[] ) => Pick<T, K>';
+      const actual =
+        'type T = <T extends object, K extends keyof T>(obj: T, ...keys: K[]) => Pick<T, K>';
+      expect(matchModuloWhitespace(actual, expected)).toBe(true);
+    });
+
+    it('should flag different types', () => {
+      expect(matchModuloWhitespace('string', 'number')).toBe(false);
+    });
   });
 });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -10,7 +10,6 @@ describe('utils', () => {
 
   test('sha256', () => {
     expect(sha256('')).toMatchInlineSnapshot(
-      '',
       `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`,
     );
   });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,4 +1,4 @@
-import {matchAndExtract} from '../utils';
+import {matchAndExtract, sha256} from '../utils';
 
 describe('utils', () => {
   test('matchAndExtract', () => {
@@ -6,5 +6,12 @@ describe('utils', () => {
     expect(matchAndExtract(pat, 'foo bar')).toEqual('bar');
     expect(matchAndExtract(pat, 'hello foo bar baz')).toEqual('bar');
     expect(matchAndExtract(pat, 'foo baz')).toEqual(null);
+  });
+
+  test('sha256', () => {
+    expect(sha256('')).toMatchInlineSnapshot(
+      '',
+      `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`,
+    );
   });
 });

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -373,12 +373,15 @@ export function sortUnions(type: string): string {
 export function matchModuloWhitespace(actual: string, expected: string): boolean {
   // TODO: it's much easier to normalize actual based on the displayParts
   //       This isn't 100% correct if a type has a space in it, e.g. type T = "string literal"
-  const normalize = (input: string) =>
-    sortUnions(input)
+  const normalize = (input: string) => {
+    const [name, type] = input.split(/[:=]/, 2);
+    const normType = sortUnions(type)
       .replace(/[\n\r ]+/g, ' ')
       .replace(/\( */g, '(')
       .replace(/ *\)/, ')')
       .trim();
+    return `${name}: ${normType}`;
+  };
   const normActual = normalize(actual);
   const normExpected = normalize(expected);
   return normActual === normExpected;

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -445,7 +445,8 @@ export interface CheckTsResult {
   // TODO: include more details about errors
 }
 
-function getCheckTsCacheKey(sample: CodeSample, runCode: boolean) {
+function getCheckTsCacheKey(inSample: CodeSample, runCode: boolean) {
+  const {descriptor: _1, id: _2, sectionHeader: _3, sourceFile: _4, ...sample} = inSample;
   const key = {
     sample,
     runCode,

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -470,14 +470,13 @@ export async function checkTs(
   const hit = await fs.pathExists(tempFilePath);
   if (hit) {
     const result = await fs.readFile(tempFilePath, 'utf8');
-    console.log('🎉 Cache hit!!!');
     const {key: _, ...out} = JSON.parse(result);
     return out;
   }
 
   const result = await uncachedCheckTs(sample, runCode, config);
 
-  await fs.writeFile(tempFilePath, JSON.stringify({result, key: cacheKey}), 'utf8');
+  await fs.writeFile(tempFilePath, JSON.stringify({...result, key: cacheKey}), 'utf8');
   return result;
 }
 

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -471,11 +471,12 @@ export async function checkTs(
   sample: CodeSample,
   runCode: boolean,
   config: ConfigBundle,
+  options: {skipCache: boolean},
 ): Promise<CheckTsResult> {
   const [key, cacheKey] = getCheckTsCacheKey(sample, runCode);
   const tempFilePath = `/tmp/literate-ts-cache/${key}.json`;
   const hit = await fs.pathExists(tempFilePath);
-  if (hit) {
+  if (hit && !options.skipCache) {
     const result = await fs.readFile(tempFilePath, 'utf8');
     const {key: _, ...out} = JSON.parse(result) as CheckTsResult & {key: unknown};
     if (out.failReason) {
@@ -489,7 +490,9 @@ export async function checkTs(
     result.failReason = getLastFailReason() ?? undefined;
   }
 
-  await fs.writeFile(tempFilePath, JSON.stringify({...result, key: cacheKey}), 'utf8');
+  if (!options.skipCache) {
+    await fs.writeFile(tempFilePath, JSON.stringify({...result, key: cacheKey}), 'utf8');
+  }
   return result;
 }
 

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -346,11 +346,17 @@ function getNodeAtPosition(sourceFile: ts.SourceFile, position: number): ts.Node
   return candidate;
 }
 
-function matchModuloWhitespace(actual: string, expected: string): boolean {
+export function matchModuloWhitespace(actual: string, expected: string): boolean {
   // TODO: it's much easier to normalize actual based on the displayParts
   //       This isn't 100% correct if a type has a space in it, e.g. type T = "string literal"
-  const normActual = actual.replace(/[\n\r ]+/g, ' ').trim();
-  const normExpected = expected.replace(/[\n\r ]+/g, ' ').trim();
+  const normalize = (input: string) =>
+    input
+      .replace(/[\n\r ]+/g, ' ')
+      .replace(/\( */g, '(')
+      .replace(/ *\)/, ')')
+      .trim();
+  const normActual = normalize(actual);
+  const normExpected = normalize(expected);
   return normActual === normExpected;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,4 +32,5 @@ export interface SampleOutput {
   code: number;
   stdout: string;
   stderr: string;
+  path: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import {createHash} from 'crypto';
 import fs from 'fs';
 import tmp from 'tmp';
 import {basename} from 'path';
@@ -72,4 +73,10 @@ export function dedent(strings: TemplateStringsArray, ...values: (string | numbe
     fullString = fullString.replace(regexp, '');
   }
   return fullString;
+}
+
+export function sha256(message: string) {
+  return createHash('sha256')
+    .update(message)
+    .digest('hex');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,3 +80,5 @@ export function sha256(message: string) {
     .update(message)
     .digest('hex');
 }
+
+export const tuple = <Args extends unknown[]>(...args: Args): Args => args;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,9 @@
+import path from 'path';
+
+const packagePath = path.join(
+  __dirname,
+  // The path to package.json is slightly different when you run via ts-node
+  __dirname.includes('dist') ? '../../package.json' : '../package.json',
+);
+
+export const VERSION = require(packagePath).version;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 
+// TODO: use https://www.npmjs.com/package/read-pkg-up instead
 const packagePath = path.join(
   __dirname,
   // The path to package.json is slightly different when you run via ts-node


### PR DESCRIPTION
Verifying chapter 1 of _Effective TypeScript_, uncached:

    ✓ All 60 samples passed!
    ✨  Done in 13.76s.

Verifying cached:

    ✓ All 60 samples passed!
    ✨  Done in 0.24s.

`:sparkles:` indeed!

This adds a `--nocache` flag to bypass the cache, which is set to live in `/tmp/literate-ts-cache` with this PR (this will change in #64).

Fixes #62 
Fixes #55
