### PR TITLE
Switch from glob -> fast-glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
+    "fast-glob": "^3.3.1",
     "fast-json-stable-stringify": "^2.1.0",
     "find-cache-dir": "^4.0.0",
     "fs-extra": "^11.0.0",
-    "glob": "^7.1.4",
     "lodash": "^4.17.15",
     "ora": "^7.0.0",
     "read-pkg-up": "^10.0.0",
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@types/find-cache-dir": "^3.2.1",
     "@types/fs-extra": "^11.0.0",
-    "@types/glob": "^8.0.0",
     "@types/jest": "^29.0.0",
     "@types/lodash": "^4.14.138",
     "@types/node": "18",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path, {isAbsolute} from 'path';
 
 import chalk from 'chalk';
-import glob from 'glob';
+import glob from 'fast-glob';
 import _ from 'lodash';
 import ora from 'ora';
 import ts from 'typescript';

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import glob from 'glob';
+import glob from 'fast-glob';
 import path from 'path';
 
 import {dedent} from '../utils.js';

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import glob from 'glob';
+import glob from 'fast-glob';
 import path from 'path';
 
 import {extractSamples} from '../code-sample.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,14 +789,6 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
-"@types/glob@^8.0.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"
-  integrity sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==
-  dependencies:
-    "@types/minimatch" "^5.1.2"
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -847,11 +839,6 @@
   version "4.14.196"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.196.tgz#a7c3d6fc52d8d71328b764e28e080b4169ec7a95"
   integrity sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==
-
-"@types/minimatch@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
-  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
   version "20.4.8"
@@ -1680,7 +1667,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0:
+fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==


### PR DESCRIPTION
`glob` has a lot of deep transitive dependencies and a few seem to have some issues with ESM, see #91. This seems to reduce the total number of transitive dependencies.