### PR TITLE
Add special "type equivalent to" assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,29 @@ be careful not to mislead the reader when you do this.
 
 If you'd like to keep your source files self-contained, you can put the replacement in a code block and reference it with a `replace-with-id` directive. See [this sample file](/examples/asciidoc/failures.asciidoc) for examples.
 
+## Equivalent types
+
+Sometimes TypeScript's type display can be a bit opaque, particularly with `keyof` expressions:
+
+```ts
+interface Point {
+  x: number;
+  y: number;
+}
+
+type T = keyof Point;
+//   ^? type T = keyof Point
+```
+
+While correct and faithful to what you see in Quick Info, this isn't very useful. You can add an "equivalent to" clause to the type assertion to get some more resolution on the type (and clarify what it is for your readers):
+
+```ts
+type T = keyof Point;
+//   ^? type T = keyof Point (equivalent to "x" | "y")
+```
+
+When it sees this sort of assertion, literate-ts will quietly insert some [machinery] to resolve the type and check both the raw and resolved types.
+
 ## Command-Line Options
 
 - `--help`: Show help.
@@ -404,3 +427,4 @@ Publish a new version:
 [etsblog]: https://effectivetypescript.com/
 [pylit-post]: https://www.onebigfluke.com/2014/07/how-im-writing-programming-book.html
 [twoslash]: https://shikijs.github.io/twoslash/
+[machinery]: https://effectivetypescript.com/2022/02/25/gentips-4-display/

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -281,6 +281,8 @@ export function addResolvedChecks(sample: CodeSample): CodeSample {
   console.log(typeName, raw, equivClause, equivType);
 
   // Strip the "equivalent to" bit, add Resolve<T> helper and secondary type assertion.
+  // See https://github.com/danvk/literate-ts/issues/132 and
+  // https://effectivetypescript.com/2022/02/25/gentips-4-display/
   let newContent = content.replace(equivClause, '');
   newContent += '\ntype Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};';
   newContent += `\ntype Synth${typeName} = Resolve<${typeName}>;`;

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -268,13 +268,24 @@ export function applyReplacements(
 }
 
 const EQUIVALENT_RE = /\^\? type ([A-Za-z0-9_]+) = (.*)( \(equivalent to (.*)\))$/m;
+const EQUIVALENT_MULTILINE_RE =
+  /\^\? type ([A-Za-z0-9_]+) = (.*)\n\s*\/\/( +\(equivalent to (.*)\))$/m;
 
 /** Patch the code sample to test "equivalent to" types */
 export function addResolvedChecks(sample: CodeSample): CodeSample {
   const {content} = sample;
-  const m = EQUIVALENT_RE.exec(content);
-  if (!m) {
+  if (!content.includes('equivalent to')) {
     return sample;
+  }
+
+  let isMultilineMatch = false;
+  let m = EQUIVALENT_RE.exec(content);
+  if (!m) {
+    m = EQUIVALENT_MULTILINE_RE.exec(content);
+    if (!m) {
+      return sample;
+    }
+    isMultilineMatch = true;
   }
 
   const [, typeName, raw, equivClause, equivType] = m;
@@ -283,7 +294,7 @@ export function addResolvedChecks(sample: CodeSample): CodeSample {
   // Strip the "equivalent to" bit, add Resolve<T> helper and secondary type assertion.
   // See https://github.com/danvk/literate-ts/issues/132 and
   // https://effectivetypescript.com/2022/02/25/gentips-4-display/
-  let newContent = content.replace(equivClause, '');
+  let newContent = isMultilineMatch ? content : content.replace(equivClause, '');
   newContent += '\ntype Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};';
   newContent += `\ntype Synth${typeName} = Resolve<${typeName}>;`;
   newContent += `\n//   ^? type Synth${typeName} = ${equivType}\n`;

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -267,6 +267,31 @@ export function applyReplacements(
   return samples;
 }
 
+const EQUIVALENT_RE = /\^\? type ([A-Za-z0-9_]+) = (.*)( \(equivalent to (.*)\))$/;
+
+/** Patch the code sample to test "equivalent to" types */
+export function addResolvedChecks(sample: CodeSample): CodeSample {
+  const {content} = sample;
+  const m = EQUIVALENT_RE.exec(content);
+  if (!m) {
+    return sample;
+  }
+
+  const [, typeName, raw, equivClause, equivType] = m;
+  console.log(typeName, raw, equivClause, equivType);
+
+  // Strip the "equivalent to" bit, add Resolve<T> helper and secondary type assertion.
+  let newContent = content.replace(equivClause, '');
+  newContent += '\ntype Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};';
+  newContent += `\ntype Synth${typeName} = Resolve<${typeName}>;`;
+  newContent += `\n//   ^? type Synth${typeName} = ${equivType}\n`;
+
+  return {
+    ...sample,
+    content: newContent,
+  };
+}
+
 export function extractSamples(text: string, slug: string, sourceFile: string) {
   let processor;
   if (sourceFile.endsWith('.asciidoc')) {

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -267,7 +267,7 @@ export function applyReplacements(
   return samples;
 }
 
-const EQUIVALENT_RE = /\^\? type ([A-Za-z0-9_]+) = (.*)( \(equivalent to (.*)\))$/;
+const EQUIVALENT_RE = /\^\? type ([A-Za-z0-9_]+) = (.*)( \(equivalent to (.*)\))$/m;
 
 /** Patch the code sample to test "equivalent to" types */
 export function addResolvedChecks(sample: CodeSample): CodeSample {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import {dirname, isAbsolute} from 'path';
 
-import {applyPrefixes, extractSamples, applyReplacements} from './code-sample.js';
+import {
+  applyPrefixes,
+  extractSamples,
+  applyReplacements,
+  addResolvedChecks,
+} from './code-sample.js';
 import {fileSlug, writeTempFile} from './utils.js';
 import {log} from './logger.js';
 import {startFile, fail, finishFile, finishSample, startSample} from './test-tracker.js';
@@ -77,7 +82,7 @@ export class Processor {
     log(`Found ${rawSamples.length} code samples in ${path}`);
 
     const replacedSamples = applyReplacements(rawSamples, this.sources);
-    const samples = applyPrefixes(replacedSamples);
+    const samples = applyPrefixes(replacedSamples).map(addResolvedChecks);
 
     const outputs = _.keyBy(samples, 'id');
     for (const [i, sample] of Object.entries(samples)) {

--- a/src/test-tracker.ts
+++ b/src/test-tracker.ts
@@ -23,7 +23,7 @@ export function startSample(sample: CodeSample) {
   currentSample = sample;
   results[currentFile][sample.descriptor] = 0;
   sampleStartMs = Date.now();
-  log(`BEGIN #${sample.descriptor} (id for --filter: ${sample.id})\n`);
+  log(`BEGIN #${sample.descriptor} (--filter ${sample.id})\n`);
 }
 
 export function finishSample() {

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -103,13 +103,13 @@ END #././src/test/inputs/equivalent.asciidoc:31 (--- ms)
     "Twoslash type assertion match:",
     "  Expected: type T = keyof Point",
     "    Actual: type T = keyof Point",
-    "💥 ./src/test/inputs/equivalent.asciidoc:39:6-8: Failed type assertion for \`T2\`
-  Expected: type T2 = keyof Point (equivalent to "x" | "y" | "z")
-    Actual: type T2 = keyof Point",
-    "💥 ./src/test/inputs/equivalent.asciidoc:43:6-13: Failed type assertion for \`SynthT2\`
+    "Twoslash type assertion match:",
+    "  Expected: type T2 = keyof Point",
+    "    Actual: type T2 = keyof Point",
+    "💥 ./src/test/inputs/equivalent.asciidoc:42:6-13: Failed type assertion for \`SynthT2\`
   Expected: type SynthT2 = "x" | "y" | "z"
     Actual: type SynthT2 = "x" | "y"",
-    "  1/3 twoslash type assertions matched.",
+    "  2/3 twoslash type assertions matched.",
     "interface Point {
   x: number;
   y: number;
@@ -119,7 +119,6 @@ type T = keyof Point;
 //   ^? type T = keyof Point
 type T2 = keyof Point;
 //   ^? type T2 = keyof Point
-//      (equivalent to "x" | "y" | "z")
 type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
 type SynthT2 = Resolve<T2>;
 //   ^? type SynthT2 = "x" | "y" | "z"

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -106,7 +106,10 @@ END #././src/test/inputs/equivalent.asciidoc:31 (--- ms)
     "💥 ./src/test/inputs/equivalent.asciidoc:39:6-8: Failed type assertion for \`T2\`
   Expected: type T2 = keyof Point (equivalent to "x" | "y" | "z")
     Actual: type T2 = keyof Point",
-    "  1/2 twoslash type assertions matched.",
+    "💥 ./src/test/inputs/equivalent.asciidoc:43:6-13: Failed type assertion for \`SynthT2\`
+  Expected: type SynthT2 = "x" | "y" | "z"
+    Actual: type SynthT2 = "x" | "y"",
+    "  1/3 twoslash type assertions matched.",
     "interface Point {
   x: number;
   y: number;
@@ -116,7 +119,11 @@ type T = keyof Point;
 //   ^? type T = keyof Point
 type T2 = keyof Point;
 //   ^? type T2 = keyof Point
-//      (equivalent to "x" | "y" | "z")",
+//      (equivalent to "x" | "y" | "z")
+type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
+type SynthT2 = Resolve<T2>;
+//   ^? type SynthT2 = "x" | "y" | "z"
+",
     "tsconfig options: {"strictNullChecks":true,"module":1}",
     "
 END #././src/test/inputs/equivalent.asciidoc:39 (--- ms)

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -35,6 +35,80 @@ END #././src/test/inputs/commented-sample-with-error.asciidoc:17 (--- ms)
 }
 `;
 
+exports[`checker asciidoc checker snapshots "./src/test/inputs/equivalent.asciidoc": ./src/test/inputs/equivalent.asciidoc 1`] = `
+{
+  "logs": [
+    "---- BEGIN FILE ./src/test/inputs/equivalent.asciidoc
+",
+    "Found 3 code samples in ./src/test/inputs/equivalent.asciidoc",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:8 (id for --filter: equivalent-8)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: type T = keyof Point",
+    "    Actual: type T = keyof Point",
+    "  1/1 twoslash type assertions matched.",
+    "
+END #././src/test/inputs/equivalent.asciidoc:8 (--- ms)
+",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:23 (id for --filter: equivalent-23)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: type T = keyof Point",
+    "    Actual: type T = keyof Point",
+    "Twoslash type assertion match:",
+    "  Expected: type T2 = keyof Point",
+    "    Actual: type T2 = keyof Point",
+    "Twoslash type assertion match:",
+    "  Expected: type SynthT2 = "x" | "y"",
+    "    Actual: type SynthT2 = "x" | "y"",
+    "  3/3 twoslash type assertions matched.",
+    "
+END #././src/test/inputs/equivalent.asciidoc:23 (--- ms)
+",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:31 (id for --filter: equivalent-31)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: type T = keyof Point",
+    "    Actual: type T = keyof Point",
+    "Twoslash type assertion match:",
+    "  Expected: type T2 = keyof Point",
+    "    Actual: type T2 = keyof Point",
+    "💥 ./src/test/inputs/equivalent.asciidoc:34:6-13: Failed type assertion for \`SynthT2\`
+  Expected: type SynthT2 = "x" | "y" | "z"
+    Actual: type SynthT2 = "x" | "y"",
+    "  2/3 twoslash type assertions matched.",
+    "interface Point {
+  x: number;
+  y: number;
+}
+
+type T = keyof Point;
+//   ^? type T = keyof Point
+type T2 = keyof Point;
+//   ^? type T2 = keyof Point
+type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
+type SynthT2 = Resolve<T2>;
+//   ^? type SynthT2 = "x" | "y" | "z"
+",
+    "tsconfig options: {"strictNullChecks":true,"module":1}",
+    "
+END #././src/test/inputs/equivalent.asciidoc:31 (--- ms)
+",
+    "---- END FILE ./src/test/inputs/equivalent.asciidoc
+",
+  ],
+  "statuses": [
+    "1/1: ././src/test/inputs/equivalent.asciidoc",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 1/3 ././src/test/inputs/equivalent.asciidoc:8",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 2/3 ././src/test/inputs/equivalent.asciidoc:23",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 3/3 ././src/test/inputs/equivalent.asciidoc:31",
+  ],
+}
+`;
+
 exports[`checker asciidoc checker snapshots "./src/test/inputs/president.asciidoc": ./src/test/inputs/president.asciidoc 1`] = `
 {
   "logs": [
@@ -256,6 +330,75 @@ exports[`extractSamples snapshot: doc1 1`] = `
     "replacementId": undefined,
     "sectionHeader": null,
     "sourceFile": "doc1.asciidoc",
+    "tsOptions": {},
+  },
+]
+`;
+
+exports[`extractSamples snapshot: equivalent 1`] = `
+[
+  {
+    "checkJS": false,
+    "content": "interface Point {
+  x: number;
+  y: number;
+}
+
+type T = keyof Point;
+//   ^? type T = keyof Point",
+    "descriptor": "./equivalent.asciidoc:8",
+    "id": "equivalent-8",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 7,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "sourceFile": "equivalent.asciidoc",
+    "tsOptions": {},
+  },
+  {
+    "checkJS": false,
+    "content": "type T2 = keyof Point;
+//   ^? type T2 = keyof Point (equivalent to "x" | "y")",
+    "descriptor": "./equivalent.asciidoc:23",
+    "id": "equivalent-23",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 22,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "equivalent-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "sourceFile": "equivalent.asciidoc",
+    "tsOptions": {},
+  },
+  {
+    "checkJS": false,
+    "content": "type T2 = keyof Point;
+//   ^? type T2 = keyof Point (equivalent to "x" | "y" | "z")",
+    "descriptor": "./equivalent.asciidoc:31",
+    "id": "equivalent-31",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 30,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "equivalent-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "sourceFile": "equivalent.asciidoc",
     "tsOptions": {},
   },
 ]

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -6,7 +6,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/commented-sample-
     "---- BEGIN FILE ./src/test/inputs/commented-sample-with-error.asciidoc
 ",
     "Found 2 code samples in ./src/test/inputs/commented-sample-with-error.asciidoc",
-    "BEGIN #././src/test/inputs/commented-sample-with-error.asciidoc:7 (id for --filter: commented-sample-with-error-7)
+    "BEGIN #././src/test/inputs/commented-sample-with-error.asciidoc:7 (--filter commented-sample-with-error-7)
 ",
     "💥 ./src/test/inputs/commented-sample-with-error.asciidoc:7:7-12: Unexpected TypeScript error: Type 'string' is not assignable to type 'number'.",
     "const value: number = "123";",
@@ -14,7 +14,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/commented-sample-
     "
 END #././src/test/inputs/commented-sample-with-error.asciidoc:7 (--- ms)
 ",
-    "BEGIN #././src/test/inputs/commented-sample-with-error.asciidoc:17 (id for --filter: commented-sample-with-error-17)
+    "BEGIN #././src/test/inputs/commented-sample-with-error.asciidoc:17 (--filter commented-sample-with-error-17)
 ",
     "💥 ././src/test/inputs/commented-sample-with-error.asciidoc:17: Unexpected TypeScript error: Type 'string' is not assignable to type 'number'.",
     "const value: number = "123";
@@ -40,8 +40,8 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/equivalent.asciid
   "logs": [
     "---- BEGIN FILE ./src/test/inputs/equivalent.asciidoc
 ",
-    "Found 3 code samples in ./src/test/inputs/equivalent.asciidoc",
-    "BEGIN #././src/test/inputs/equivalent.asciidoc:8 (id for --filter: equivalent-8)
+    "Found 4 code samples in ./src/test/inputs/equivalent.asciidoc",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:8 (--filter equivalent-8)
 ",
     "Code passed type checker.",
     "Twoslash type assertion match:",
@@ -51,7 +51,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/equivalent.asciid
     "
 END #././src/test/inputs/equivalent.asciidoc:8 (--- ms)
 ",
-    "BEGIN #././src/test/inputs/equivalent.asciidoc:23 (id for --filter: equivalent-23)
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:23 (--filter equivalent-23)
 ",
     "Code passed type checker.",
     "Twoslash type assertion match:",
@@ -67,7 +67,7 @@ END #././src/test/inputs/equivalent.asciidoc:8 (--- ms)
     "
 END #././src/test/inputs/equivalent.asciidoc:23 (--- ms)
 ",
-    "BEGIN #././src/test/inputs/equivalent.asciidoc:31 (id for --filter: equivalent-31)
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:31 (--filter equivalent-31)
 ",
     "Code passed type checker.",
     "Twoslash type assertion match:",
@@ -97,14 +97,39 @@ type SynthT2 = Resolve<T2>;
     "
 END #././src/test/inputs/equivalent.asciidoc:31 (--- ms)
 ",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:39 (--filter equivalent-39)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: type T = keyof Point",
+    "    Actual: type T = keyof Point",
+    "💥 ./src/test/inputs/equivalent.asciidoc:39:6-8: Failed type assertion for \`T2\`
+  Expected: type T2 = keyof Point (equivalent to "x" | "y" | "z")
+    Actual: type T2 = keyof Point",
+    "  1/2 twoslash type assertions matched.",
+    "interface Point {
+  x: number;
+  y: number;
+}
+
+type T = keyof Point;
+//   ^? type T = keyof Point
+type T2 = keyof Point;
+//   ^? type T2 = keyof Point
+//      (equivalent to "x" | "y" | "z")",
+    "tsconfig options: {"strictNullChecks":true,"module":1}",
+    "
+END #././src/test/inputs/equivalent.asciidoc:39 (--- ms)
+",
     "---- END FILE ./src/test/inputs/equivalent.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/equivalent.asciidoc",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 1/3 ././src/test/inputs/equivalent.asciidoc:8",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 2/3 ././src/test/inputs/equivalent.asciidoc:23",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 3/3 ././src/test/inputs/equivalent.asciidoc:31",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 1/4 ././src/test/inputs/equivalent.asciidoc:8",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 2/4 ././src/test/inputs/equivalent.asciidoc:23",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 3/4 ././src/test/inputs/equivalent.asciidoc:31",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 4/4 ././src/test/inputs/equivalent.asciidoc:39",
   ],
 }
 `;
@@ -115,7 +140,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/president.asciido
     "---- BEGIN FILE ./src/test/inputs/president.asciidoc
 ",
     "Found 2 code samples in ./src/test/inputs/president.asciidoc",
-    "BEGIN #././src/test/inputs/president.asciidoc:7 (id for --filter: president-7)
+    "BEGIN #././src/test/inputs/president.asciidoc:7 (--filter president-7)
 ",
     "Code passed type checker.",
     "💥 ./src/test/inputs/president.asciidoc:9:7-16: Failed type assertion for \`president\`
@@ -138,7 +163,7 @@ const president = {...firstLast, ...(hasMiddle ? {middle: 'S'} : {})};
     "
 END #././src/test/inputs/president.asciidoc:7 (--- ms)
 ",
-    "BEGIN #././src/test/inputs/president.asciidoc:21 (id for --filter: president-21)
+    "BEGIN #././src/test/inputs/president.asciidoc:21 (--filter president-21)
 ",
     "Code passed type checker.",
     "💥 ./src/test/inputs/president.asciidoc:23:7-16: Failed type assertion for \`const president = {...firstLast, ...(hasMiddle ? {middle: 'S'} : {})};\` (tested \`president\`)
@@ -389,6 +414,28 @@ type T = keyof Point;
     "isTSX": false,
     "language": "ts",
     "lineNumber": 30,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "equivalent-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "sourceFile": "equivalent.asciidoc",
+    "tsOptions": {},
+  },
+  {
+    "checkJS": false,
+    "content": "type T2 = keyof Point;
+//   ^? type T2 = keyof Point
+//      (equivalent to "x" | "y" | "z")",
+    "descriptor": "./equivalent.asciidoc:39",
+    "id": "equivalent-39",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 38,
     "nodeModules": [],
     "prefixes": [
       {

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -448,6 +448,7 @@ describe('checker', () => {
   test.each([
     './src/test/inputs/commented-sample-with-error.asciidoc',
     './src/test/inputs/president.asciidoc',
+    './src/test/inputs/equivalent.asciidoc',
   ])(
     'asciidoc checker snapshots %p',
     async inputFile => {

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -415,7 +415,26 @@ describe('applyReplacements', () => {
 });
 
 describe('addResolvedChecks', () => {
-  it('should leave most code samples alone', () => {});
+  it('should leave most code samples alone', () => {
+    const sample = applyPrefixes(
+      extractSamples(
+        dedent`
+          [source,ts]
+          ----
+          interface Point {
+            x: number;
+            y: number;
+          }
+          type T = keyof Point;
+          //   ^? type T = keyof Point
+          ----
+          `,
+        'equivalent-assertion',
+        'source.asciidoc',
+      ),
+    );
+    expect(addResolvedChecks(sample[0])).toEqual(sample[0]);
+  });
 
   it('should patch a code sample with an "equivalent to" assertion', () => {
     const sample = applyPrefixes(

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -528,4 +528,32 @@ describe('addResolvedChecks', () => {
       //   ^? type SynthPointKeys = "x" | "y"
       `);
   });
+
+  it('should patch a type assertion split across lines', () => {
+    const sample = applyPrefixes(
+      extractSamples(
+        dedent`
+          You can also split the assertion onto another line:
+
+          [source,ts]
+          ----
+          type T2 = keyof Point;
+          //   ^? type T2 = keyof Point
+          //      (equivalent to "x" | "y")
+          ----
+        `,
+        'equivalent-assertion',
+        'source.asciidoc',
+      ),
+    );
+
+    expect(addResolvedChecks(sample[0]).content).toEqual(dedent`
+      type T2 = keyof Point;
+      //   ^? type T2 = keyof Point
+      //      (equivalent to "x" | "y")
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
+      type SynthT2 = Resolve<T2>;
+      //   ^? type SynthT2 = "x" | "y"
+      `);
+  });
 });

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -550,7 +550,6 @@ describe('addResolvedChecks', () => {
     expect(addResolvedChecks(sample[0]).content).toEqual(dedent`
       type T2 = keyof Point;
       //   ^? type T2 = keyof Point
-      //      (equivalent to "x" | "y")
       type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type SynthT2 = Resolve<T2>;
       //   ^? type SynthT2 = "x" | "y"

--- a/src/test/inputs/equivalent.asciidoc
+++ b/src/test/inputs/equivalent.asciidoc
@@ -31,3 +31,12 @@ Errors should be reported though probably not in a relevant location:
 type T2 = keyof Point;
 //   ^? type T2 = keyof Point (equivalent to "x" | "y" | "z")
 ----
+
+You can also split the assertion onto another line:
+
+[source,ts]
+----
+type T2 = keyof Point;
+//   ^? type T2 = keyof Point
+//      (equivalent to "x" | "y" | "z")
+----

--- a/src/test/inputs/equivalent.asciidoc
+++ b/src/test/inputs/equivalent.asciidoc
@@ -1,0 +1,33 @@
+See https://github.com/danvk/literate-ts/issues/132 for context.
+
+As of TS 4.2, `keyof` expressions resolve in an opaque and not very useful way:
+
+// verifier:prepend-to-following
+[source,ts]
+----
+interface Point {
+  x: number;
+  y: number;
+}
+
+type T = keyof Point;
+//   ^? type T = keyof Point
+----
+
+You can use some https://effectivetypescript.com/2022/02/25/gentips-4-display/[machinery] to inline the type, but this usually distracts from the point of the text.
+
+There's a special "equivalent to" syntax that quietly inserts some helper code to resolve the type behind the scenes:
+
+[source,ts]
+----
+type T2 = keyof Point;
+//   ^? type T2 = keyof Point (equivalent to "x" | "y")
+----
+
+Errors should be reported though probably not in a relevant location:
+
+[source,ts]
+----
+type T2 = keyof Point;
+//   ^? type T2 = keyof Point (equivalent to "x" | "y" | "z")
+----


### PR DESCRIPTION
Fixes #132 

Instead of:

```ts
interface Point {
  x: number;
  y: number;
}

type T = keyof Point;
//   ^? type T = keyof Point
```

You can now write:

```ts
interface Point {
  x: number;
  y: number;
}

type T = keyof Point;
//   ^? type T = keyof Point (equivalent to "x" | "y")
```

and literate-ts will quietly insert some [machinery](https://effectivetypescript.com/2022/02/25/gentips-4-display/) to resolve the type and check that, too.