### PR TITLE
Support JSON/JSONC sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "find-cache-dir": "^5.0.0",
     "fs-extra": "^11.0.0",
     "html-to-text": "^9.0.5",
+    "jsonc-parser": "^3.2.0",
     "lodash": "^4.17.15",
     "ora": "^7.0.0",
     "read-pkg-up": "^10.0.0",

--- a/src/asciidoc.ts
+++ b/src/asciidoc.ts
@@ -4,7 +4,7 @@ import {generateIdMetadata} from './metadata.js';
 
 const EXTRACT_BACKTICKS = /```(tsx|ts)/;
 const EXTRACT_ID = /\[\[([^\]]*)\]\]/;
-const EXTRACT_SOURCE = /\[source,(ts|js)\]/;
+const EXTRACT_SOURCE = /\[source,(ts|js|json)\]/;
 const EXTRACT_DIRECTIVE = /^\/\/ verifier:(.*)$/;
 const TOP_HEADER = /^={1,3} (.*)$/;
 const NODE_PROGRAM_LISTING = /<pre data-type="programlisting".*>&gt; /;

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import {ParseError, parse as parseJSONC, printParseErrorCode} from 'jsonc-parser';
 import {dirname, isAbsolute} from 'path';
 
 import {
@@ -126,6 +127,13 @@ export class Processor {
     } else if (language === 'node') {
       // Node.js CLI "program listing"
       await checkProgramListing(sample, this.typeScriptBundle);
+    } else if (language === 'json') {
+      const errors: ParseError[] = [];
+      parseJSONC(sample.content, errors);
+      if (errors.length) {
+        const errorsTxt = errors.map(e => printParseErrorCode(e.error));
+        fail(`Invalid JSONC: ${errorsTxt}`);
+      }
     } else if (language === null && id.endsWith('-output')) {
       // Verify the output of a previous code sample.
       const inputId = id.split('-output')[0];

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`checker asciidoc checker snapshots "./src/test/inputs/check-jsonc.asciidoc": ./src/test/inputs/check-jsonc.asciidoc 1`] = `
+{
+  "logs": [
+    "---- BEGIN FILE ./src/test/inputs/check-jsonc.asciidoc
+",
+    "Found 0 code samples in ./src/test/inputs/check-jsonc.asciidoc",
+    "---- END FILE ./src/test/inputs/check-jsonc.asciidoc
+",
+  ],
+  "statuses": [
+    "1/1: ././src/test/inputs/check-jsonc.asciidoc",
+  ],
+}
+`;
+
 exports[`checker asciidoc checker snapshots "./src/test/inputs/commented-sample-with-error.asciidoc": ./src/test/inputs/commented-sample-with-error.asciidoc 1`] = `
 {
   "logs": [
@@ -213,7 +228,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/prepend-as-file.a
   "logs": [
     "---- BEGIN FILE ./src/test/inputs/prepend-as-file.asciidoc
 ",
-    "Found 2 code samples in ./src/test/inputs/prepend-as-file.asciidoc",
+    "Found 3 code samples in ./src/test/inputs/prepend-as-file.asciidoc",
     "BEGIN #././src/test/inputs/prepend-as-file.asciidoc:10 (--filter prepend-as-file-10)
 ",
     "Code passed type checker.",
@@ -231,13 +246,26 @@ END #././src/test/inputs/prepend-as-file.asciidoc:10 (--- ms)
     "
 END #././src/test/inputs/prepend-as-file.asciidoc:21 (--- ms)
 ",
+    "BEGIN #././src/test/inputs/prepend-as-file.asciidoc:52 (--filter prepend-as-file-52)
+",
+    "💥 ./src/test/inputs/prepend-as-file.asciidoc:52:18-31: Unexpected TypeScript error: Cannot find module './data.json' or its corresponding type declarations.",
+    "import data from './data.json';
+console.log(data.year);
+//               ^? (property) data.year: string
+console.log(data.months);
+//               ^? (property) data.months: string[]",
+    "tsconfig options: {"strictNullChecks":true,"module":1,"resolveJsonModule":true}",
+    "
+END #././src/test/inputs/prepend-as-file.asciidoc:52 (--- ms)
+",
     "---- END FILE ./src/test/inputs/prepend-as-file.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/prepend-as-file.asciidoc",
-    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 1/2 ././src/test/inputs/prepend-as-file.asciidoc:10",
-    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 2/2 ././src/test/inputs/prepend-as-file.asciidoc:21",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 1/3 ././src/test/inputs/prepend-as-file.asciidoc:10",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 2/3 ././src/test/inputs/prepend-as-file.asciidoc:21",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 3/3 ././src/test/inputs/prepend-as-file.asciidoc:52",
   ],
 }
 `;
@@ -413,6 +441,8 @@ exports[`extractSamples snapshot: backticks 1`] = `
 `;
 
 exports[`extractSamples snapshot: backticks-disabled 1`] = `[]`;
+
+exports[`extractSamples snapshot: check-jsonc 1`] = `[]`;
 
 exports[`extractSamples snapshot: commented-sample 1`] = `
 [
@@ -997,6 +1027,31 @@ const pt: Point = {
     "sourceFile": "prepend-as-file.asciidoc",
     "targetFilename": null,
     "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "import data from './data.json';
+console.log(data.year);
+//               ^? (property) data.year: string
+console.log(data.months);
+//               ^? (property) data.months: string[]",
+    "descriptor": "./prepend-as-file.asciidoc:52",
+    "id": "prepend-as-file-52",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 51,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "prepend-as-file.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {
+      "resolveJsonModule": true,
+    },
   },
 ]
 `;

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -5,12 +5,25 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/check-jsonc.ascii
   "logs": [
     "---- BEGIN FILE ./src/test/inputs/check-jsonc.asciidoc
 ",
-    "Found 0 code samples in ./src/test/inputs/check-jsonc.asciidoc",
+    "Found 2 code samples in ./src/test/inputs/check-jsonc.asciidoc",
+    "BEGIN #././src/test/inputs/check-jsonc.asciidoc:5 (--filter check-jsonc-5)
+",
+    "
+END #././src/test/inputs/check-jsonc.asciidoc:5 (--- ms)
+",
+    "BEGIN #././src/test/inputs/check-jsonc.asciidoc:21 (--filter check-jsonc-21)
+",
+    "💥 ././src/test/inputs/check-jsonc.asciidoc:21: Invalid JSONC: InvalidSymbol,PropertyNameExpected,ValueExpected,InvalidSymbol,UnexpectedEndOfString,ColonExpected,PropertyNameExpected,ValueExpected",
+    "
+END #././src/test/inputs/check-jsonc.asciidoc:21 (--- ms)
+",
     "---- END FILE ./src/test/inputs/check-jsonc.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/check-jsonc.asciidoc",
+    "1/1: ././src/test/inputs/check-jsonc.asciidoc: 1/2 ././src/test/inputs/check-jsonc.asciidoc:5",
+    "1/1: ././src/test/inputs/check-jsonc.asciidoc: 2/2 ././src/test/inputs/check-jsonc.asciidoc:21",
   ],
 }
 `;
@@ -228,7 +241,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/prepend-as-file.a
   "logs": [
     "---- BEGIN FILE ./src/test/inputs/prepend-as-file.asciidoc
 ",
-    "Found 3 code samples in ./src/test/inputs/prepend-as-file.asciidoc",
+    "Found 4 code samples in ./src/test/inputs/prepend-as-file.asciidoc",
     "BEGIN #././src/test/inputs/prepend-as-file.asciidoc:10 (--filter prepend-as-file-10)
 ",
     "Code passed type checker.",
@@ -246,26 +259,33 @@ END #././src/test/inputs/prepend-as-file.asciidoc:10 (--- ms)
     "
 END #././src/test/inputs/prepend-as-file.asciidoc:21 (--- ms)
 ",
-    "BEGIN #././src/test/inputs/prepend-as-file.asciidoc:52 (--filter prepend-as-file-52)
+    "BEGIN #././src/test/inputs/prepend-as-file.asciidoc:37 (--filter prepend-as-file-37)
 ",
-    "💥 ./src/test/inputs/prepend-as-file.asciidoc:52:18-31: Unexpected TypeScript error: Cannot find module './data.json' or its corresponding type declarations.",
-    "import data from './data.json';
-console.log(data.year);
-//               ^? (property) data.year: string
-console.log(data.months);
-//               ^? (property) data.months: string[]",
-    "tsconfig options: {"strictNullChecks":true,"module":1,"resolveJsonModule":true}",
     "
-END #././src/test/inputs/prepend-as-file.asciidoc:52 (--- ms)
+END #././src/test/inputs/prepend-as-file.asciidoc:37 (--- ms)
+",
+    "BEGIN #././src/test/inputs/prepend-as-file.asciidoc:53 (--filter prepend-as-file-53)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: (property) "year": number",
+    "    Actual: (property) "year": number",
+    "Twoslash type assertion match:",
+    "  Expected: (property) "months": string[]",
+    "    Actual: (property) "months": string[]",
+    "  2/2 twoslash type assertions matched.",
+    "
+END #././src/test/inputs/prepend-as-file.asciidoc:53 (--- ms)
 ",
     "---- END FILE ./src/test/inputs/prepend-as-file.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/prepend-as-file.asciidoc",
-    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 1/3 ././src/test/inputs/prepend-as-file.asciidoc:10",
-    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 2/3 ././src/test/inputs/prepend-as-file.asciidoc:21",
-    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 3/3 ././src/test/inputs/prepend-as-file.asciidoc:52",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 1/4 ././src/test/inputs/prepend-as-file.asciidoc:10",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 2/4 ././src/test/inputs/prepend-as-file.asciidoc:21",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 3/4 ././src/test/inputs/prepend-as-file.asciidoc:37",
+    "1/1: ././src/test/inputs/prepend-as-file.asciidoc: 4/4 ././src/test/inputs/prepend-as-file.asciidoc:53",
   ],
 }
 `;
@@ -442,7 +462,62 @@ exports[`extractSamples snapshot: backticks 1`] = `
 
 exports[`extractSamples snapshot: backticks-disabled 1`] = `[]`;
 
-exports[`extractSamples snapshot: check-jsonc 1`] = `[]`;
+exports[`extractSamples snapshot: check-jsonc 1`] = `
+[
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "// data.json
+{
+  "year": 2023,
+  "months": [
+    "Jan",
+    "Feb",
+    /* ... */
+    "Dec"
+  ]
+}",
+    "descriptor": "./check-jsonc.asciidoc:5",
+    "id": "check-jsonc-5",
+    "isTSX": false,
+    "language": "json",
+    "lineNumber": 4,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "check-jsonc.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "{
+  year: 2023,
+  months": [
+    "Jan",
+  ]
+}",
+    "descriptor": "./check-jsonc.asciidoc:21",
+    "id": "check-jsonc-21",
+    "isTSX": false,
+    "language": "json",
+    "lineNumber": 20,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "check-jsonc.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+]
+`;
 
 exports[`extractSamples snapshot: commented-sample 1`] = `
 [
@@ -1031,16 +1106,21 @@ const pt: Point = {
   {
     "auxiliaryFiles": [],
     "checkJS": false,
-    "content": "import data from './data.json';
-console.log(data.year);
-//               ^? (property) data.year: string
-console.log(data.months);
-//               ^? (property) data.months: string[]",
-    "descriptor": "./prepend-as-file.asciidoc:52",
-    "id": "prepend-as-file-52",
+    "content": "// data.json
+{
+  "year": 2023,
+  "months": [
+    "Jan",
+    "Feb",
+    /* ... */
+    "Dec"
+  ]
+}",
+    "descriptor": "./prepend-as-file.asciidoc:37",
+    "id": "prepend-as-file-37",
     "isTSX": false,
-    "language": "ts",
-    "lineNumber": 51,
+    "language": "json",
+    "lineNumber": 36,
     "nodeModules": [],
     "prefixes": [],
     "prefixesLength": 0,
@@ -1048,8 +1128,36 @@ console.log(data.months);
     "sectionHeader": null,
     "skip": false,
     "sourceFile": "prepend-as-file.asciidoc",
+    "targetFilename": "data.json",
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "import data from './data.json';
+console.log(data.year);
+//               ^? (property) "year": number
+console.log(data.months);
+//               ^? (property) "months": string[]",
+    "descriptor": "./prepend-as-file.asciidoc:53",
+    "id": "prepend-as-file-53",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 52,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "prepend-as-file-37",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "prepend-as-file.asciidoc",
     "targetFilename": null,
     "tsOptions": {
+      "esModuleInterop": true,
       "resolveJsonModule": true,
     },
   },

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -469,6 +469,7 @@ describe('checker', () => {
     './src/test/inputs/prepend-and-skip.asciidoc',
     './src/test/inputs/program-listing.asciidoc',
     './src/test/inputs/prepend-as-file.asciidoc',
+    './src/test/inputs/check-jsonc.asciidoc',
   ])(
     'asciidoc checker snapshots %p',
     async inputFile => {

--- a/src/test/inputs/check-jsonc.asciidoc
+++ b/src/test/inputs/check-jsonc.asciidoc
@@ -1,0 +1,27 @@
+This is valid JSONC:
+
+[source,json]
+----
+// data.json
+{
+  "year": 2023,
+  "months": [
+    "Jan",
+    "Feb",
+    /* ... */
+    "Dec"
+  ]
+}
+----
+
+This is invalid JSONC:
+
+[source,json]
+----
+{
+  year: 2023,
+  months": [
+    "Jan",
+  ]
+}
+----

--- a/src/test/inputs/prepend-as-file.asciidoc
+++ b/src/test/inputs/prepend-as-file.asciidoc
@@ -47,11 +47,12 @@ You can also import a JSON file. As a convenience, literate-ts will convert from
 ----
 
 // verifier:tsconfig:resolveJsonModule=true
+// verifier:tsconfig:esModuleInterop=true
 [source,ts]
 ----
 import data from './data.json';
 console.log(data.year);
-//               ^? (property) data.year: string
+//               ^? (property) "year": number
 console.log(data.months);
-//               ^? (property) data.months: string[]
+//               ^? (property) "months": string[]
 ----

--- a/src/test/inputs/prepend-as-file.asciidoc
+++ b/src/test/inputs/prepend-as-file.asciidoc
@@ -28,3 +28,30 @@ const pt: Point = {
 }
 ----
 // verifier:reset
+
+You can also import a JSON file. As a convenience, literate-ts will convert from JSONC (JSON with Comments) to JSON for you:
+
+// verifier:prepend-as-file:data.json
+[source,json]
+----
+// data.json
+{
+  "year": 2023,
+  "months": [
+    "Jan",
+    "Feb",
+    /* ... */
+    "Dec"
+  ]
+}
+----
+
+// verifier:tsconfig:resolveJsonModule=true
+[source,ts]
+----
+import data from './data.json';
+console.log(data.year);
+//               ^? (property) data.year: string
+console.log(data.months);
+//               ^? (property) data.months: string[]
+----

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface IdMetadata {
 export interface CodeSample {
   /** file.ext:line for this code sample */
   descriptor: string;
-  language: 'js' | 'ts' | 'node' | null;
+  language: 'js' | 'ts' | 'node' | 'json' | null;
   /** either user-supplied sample ID or file-line */
   id: string;
   sectionHeader: string | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,6 +2612,11 @@ json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonc-parser@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
+  integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"


### PR DESCRIPTION
Follow-up to #150. This allows importing JSON modules. As a convenience, sources are assumed to be JSONC and they're converted to JSON as literate-ts writes them out.