### PR TITLE
Strip filename from Node stack traces

### DIFF
--- a/src/node-runner.ts
+++ b/src/node-runner.ts
@@ -1,5 +1,6 @@
 import {exec} from 'child_process';
 import util from 'util';
+import {basename} from 'node:path';
 
 import {log} from './logger.js';
 
@@ -18,7 +19,7 @@ export async function runNode(path: string): Promise<ExecErrorType> {
   } catch (eIn) {
     const e = eIn as ExecErrorType;
     const {code, stderr, stdout} = e;
-    log(`Node exited with error ${e.code} on ${path}`);
+    log(`Node exited with error ${e.code} on ${basename(path)}`);
     return {code, stderr, stdout, path};
   }
 }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -31,7 +31,7 @@ function checkOutput(expectedOutput: string, input: CodeSample) {
     .filter(line => !line.startsWith('    at ')) // prune stack traces to one line
     .filter(line => !line.match(/^Node.js v\d+/)) // Newer versions of Node log a version number
     // Remove temp paths which vary from run to run.
-    .map(line => (tmpDir ? line.replace('/private' + tmpDir, '').replace(tmpDir, '') : line))
+    .filter(line => !tmpDir || !line.includes(tmpDir))
     .join('\n')
     .trim();
   // remove markers

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -234,26 +234,13 @@ END #././src/test/inputs/node-output.asciidoc:8 (--- ms)
     "  Expected: const x: number",
     "    Actual: const x: number",
     "  2/2 twoslash type assertions matched.",
-    "Node exited with error 1 on /var/folders/t_/3xnk295j79v51cmlqvtnhslc0000gn/T/tmp-26207-zq1rvicZqjkp/unsound-code.js",
+    "Node exited with error 1 on /var/folders/t_/3xnk295j79v51cmlqvtnhslc0000gn/T/tmp-26728-vQzLv3zTJ0QK/unsound-code.js",
     "
 END #././src/test/inputs/node-output.asciidoc:16 (--- ms)
 ",
     "BEGIN #././src/test/inputs/node-output.asciidoc:24 (--filter unsound-code-output)
 ",
-    "💥 ././src/test/inputs/node-output.asciidoc:24: Actual output from Node did not match expected output.",
-    "Expected:",
-    "console.log(x.toFixed(1));
-              ^
-
-TypeError: Cannot read properties of undefined (reading 'toFixed')",
-    "----",
-    "Actual:",
-    "/unsound-code.js:5
-console.log(x.toFixed(1));
-              ^
-
-TypeError: Cannot read properties of undefined (reading 'toFixed')",
-    "----",
+    "Actual output matched expected.",
     "
 END #././src/test/inputs/node-output.asciidoc:24 (--- ms)
 ",

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -205,6 +205,70 @@ END #././src/test/inputs/equivalent.asciidoc:39 (--- ms)
 }
 `;
 
+exports[`checker asciidoc checker snapshots "./src/test/inputs/node-output.asciidoc": ./src/test/inputs/node-output.asciidoc 1`] = `
+{
+  "logs": [
+    "---- BEGIN FILE ./src/test/inputs/node-output.asciidoc
+",
+    "Found 3 code samples in ./src/test/inputs/node-output.asciidoc",
+    "BEGIN #././src/test/inputs/node-output.asciidoc:8 (--filter node-output-8)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: const xs: number[]",
+    "    Actual: const xs: number[]",
+    "Twoslash type assertion match:",
+    "  Expected: const x: number",
+    "    Actual: const x: number",
+    "  2/2 twoslash type assertions matched.",
+    "
+END #././src/test/inputs/node-output.asciidoc:8 (--- ms)
+",
+    "BEGIN #././src/test/inputs/node-output.asciidoc:16 (--filter unsound-code)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: const xs: number[]",
+    "    Actual: const xs: number[]",
+    "Twoslash type assertion match:",
+    "  Expected: const x: number",
+    "    Actual: const x: number",
+    "  2/2 twoslash type assertions matched.",
+    "Node exited with error 1 on /var/folders/t_/3xnk295j79v51cmlqvtnhslc0000gn/T/tmp-26207-zq1rvicZqjkp/unsound-code.js",
+    "
+END #././src/test/inputs/node-output.asciidoc:16 (--- ms)
+",
+    "BEGIN #././src/test/inputs/node-output.asciidoc:24 (--filter unsound-code-output)
+",
+    "💥 ././src/test/inputs/node-output.asciidoc:24: Actual output from Node did not match expected output.",
+    "Expected:",
+    "console.log(x.toFixed(1));
+              ^
+
+TypeError: Cannot read properties of undefined (reading 'toFixed')",
+    "----",
+    "Actual:",
+    "/unsound-code.js:5
+console.log(x.toFixed(1));
+              ^
+
+TypeError: Cannot read properties of undefined (reading 'toFixed')",
+    "----",
+    "
+END #././src/test/inputs/node-output.asciidoc:24 (--- ms)
+",
+    "---- END FILE ./src/test/inputs/node-output.asciidoc
+",
+  ],
+  "statuses": [
+    "1/1: ././src/test/inputs/node-output.asciidoc",
+    "1/1: ././src/test/inputs/node-output.asciidoc: 1/3 ././src/test/inputs/node-output.asciidoc:8",
+    "1/1: ././src/test/inputs/node-output.asciidoc: 2/3 ././src/test/inputs/node-output.asciidoc:16",
+    "1/1: ././src/test/inputs/node-output.asciidoc: 3/3 ././src/test/inputs/node-output.asciidoc:24",
+  ],
+}
+`;
+
 exports[`checker asciidoc checker snapshots "./src/test/inputs/prepend-and-skip.asciidoc": ./src/test/inputs/prepend-and-skip.asciidoc 1`] = `
 {
   "logs": [
@@ -905,6 +969,82 @@ exports[`extractSamples snapshot: multilinetype 1`] = `
     "sectionHeader": null,
     "skip": false,
     "sourceFile": "multilinetype.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+]
+`;
+
+exports[`extractSamples snapshot: node-output 1`] = `
+[
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "const xs = [0, 1, 2];
+//    ^? const xs: number[]
+const x = xs[3];
+//    ^? const x: number",
+    "descriptor": "./node-output.asciidoc:8",
+    "id": "node-output-8",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 7,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "node-output.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "console.log(x.toFixed(1));",
+    "descriptor": "./node-output.asciidoc:16",
+    "id": "unsound-code",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 18,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "node-output-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "node-output.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "console.log(x.toFixed(1));
+              ^
+
+TypeError: Cannot read properties of undefined (reading 'toFixed')",
+    "descriptor": "./node-output.asciidoc:24",
+    "id": "unsound-code-output",
+    "isTSX": false,
+    "language": null,
+    "lineNumber": 25,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "node-output-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "node-output.asciidoc",
     "targetFilename": null,
     "tsOptions": {},
   },

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -234,7 +234,7 @@ END #././src/test/inputs/node-output.asciidoc:8 (--- ms)
     "  Expected: const x: number",
     "    Actual: const x: number",
     "  2/2 twoslash type assertions matched.",
-    "Node exited with error 1 on /var/folders/t_/3xnk295j79v51cmlqvtnhslc0000gn/T/tmp-26728-vQzLv3zTJ0QK/unsound-code.js",
+    "Node exited with error 1 on unsound-code.js",
     "
 END #././src/test/inputs/node-output.asciidoc:16 (--- ms)
 ",

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -470,6 +470,7 @@ describe('checker', () => {
     './src/test/inputs/program-listing.asciidoc',
     './src/test/inputs/prepend-as-file.asciidoc',
     './src/test/inputs/check-jsonc.asciidoc',
+    './src/test/inputs/node-output.asciidoc',
   ])(
     'asciidoc checker snapshots %p',
     async inputFile => {

--- a/src/test/inputs/node-output.asciidoc
+++ b/src/test/inputs/node-output.asciidoc
@@ -1,0 +1,42 @@
+literate-ts can strip irrelevant details from Node output like the name of the file being tested in a stack trace.
+
+Here's an example of unsoundness in TypeScript:
+
+// verifier:prepend-to-following
+[source,ts]
+----
+const xs = [0, 1, 2];
+//    ^? const xs: number[]
+const x = xs[3];
+//    ^? const x: number
+----
+
+The static type of `x` is `number` but its value at runtime is `undefined`. Here's how this can lead to problems:
+
+[[unsound-code]]
+[source,ts]
+----
+console.log(x.toFixed(1));
+----
+
+There are no type errors, but when you run this code it will throw an error:
+
+[[unsound-code-output]]
+----
+console.log(x.toFixed(1));
+              ^
+
+TypeError: Cannot read properties of undefined (reading 'toFixed')
+----
+
+The actual error looks like this:
+
+----
+file:///path/to/unsound-code.js:6
+console.log(x.toFixed(1));
+              ^
+
+TypeError: Cannot read properties of undefined (reading 'toFixed')
+----
+
+But literate-ts has stripped out the file name for us.

--- a/src/test/inputs/node-output.asciidoc
+++ b/src/test/inputs/node-output.asciidoc
@@ -37,6 +37,14 @@ console.log(x.toFixed(1));
               ^
 
 TypeError: Cannot read properties of undefined (reading 'toFixed')
+    at file:///Users/danvk/github/literate-ts/dist/unsound-code.js:6:15
+    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
+    at async Promise.all (index 0)
+    at async ESMLoader.import (node:internal/modules/esm/loader:528:24)
+    at async loadESM (node:internal/process/esm_loader:91:5)
+    at async handleMainPromise (node:internal/modules/run_main:65:12)
+
+Node.js v18.8.0
 ----
 
-But literate-ts has stripped out the file name for us.
+But literate-ts has stripped out the file name, the stack trace and the Node version for us.


### PR DESCRIPTION
Fixes #162 

Of all the `-output` checks in _Effective TypeScript_, there's only one that keeps the file name visible to the user. And that seems like an accident. This should result in much simpler output checking in the vast majority of cases.