### PR TITLE
fix: check type assertions involving arrow functions

### DIFF
--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -205,6 +205,35 @@ END #././src/test/inputs/equivalent.asciidoc:39 (--- ms)
 }
 `;
 
+exports[`checker asciidoc checker snapshots "./src/test/inputs/issue-235.asciidoc": ./src/test/inputs/issue-235.asciidoc 1`] = `
+{
+  "logs": [
+    "---- BEGIN FILE ./src/test/inputs/issue-235.asciidoc
+",
+    "Found 1 code samples in ./src/test/inputs/issue-235.asciidoc",
+    "BEGIN #././src/test/inputs/issue-235.asciidoc:5 (--filter issue-235-5)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: const numArgsBad: (...args: any) => any",
+    "    Actual: const numArgsBad: (...args: any) => any",
+    "Twoslash type assertion match:",
+    "  Expected: const numArgsBetter: (...args: any) => numberjsdklfjklsd",
+    "    Actual: const numArgsBetter: (...args: any[]) => number",
+    "  2/2 twoslash type assertions matched.",
+    "
+END #././src/test/inputs/issue-235.asciidoc:5 (--- ms)
+",
+    "---- END FILE ./src/test/inputs/issue-235.asciidoc
+",
+  ],
+  "statuses": [
+    "1/1: ././src/test/inputs/issue-235.asciidoc",
+    "1/1: ././src/test/inputs/issue-235.asciidoc: 1/1 ././src/test/inputs/issue-235.asciidoc:5",
+  ],
+}
+`;
+
 exports[`checker asciidoc checker snapshots "./src/test/inputs/node-output.asciidoc": ./src/test/inputs/node-output.asciidoc 1`] = `
 {
   "logs": [
@@ -953,6 +982,33 @@ exports[`extractSamples snapshot: inline-replacement 1`] = `
     "sectionHeader": null,
     "skip": false,
     "sourceFile": "inline-replacement.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+]
+`;
+
+exports[`extractSamples snapshot: issue-235 1`] = `
+[
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "const numArgsBad = (...args: any) => args.length;
+//    ^? const numArgsBad: (...args: any) => any
+const numArgsBetter = (...args: any[]) => args.length;
+//    ^? const numArgsBetter: (...args: any) => numberjsdklfjklsd",
+    "descriptor": "./issue-235.asciidoc:5",
+    "id": "issue-235-5",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 4,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "issue-235.asciidoc",
     "targetFilename": null,
     "tsOptions": {},
   },

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -217,10 +217,15 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/issue-235.asciido
     "Twoslash type assertion match:",
     "  Expected: const numArgsBad: (...args: any) => any",
     "    Actual: const numArgsBad: (...args: any) => any",
-    "Twoslash type assertion match:",
-    "  Expected: const numArgsBetter: (...args: any) => numberjsdklfjklsd",
-    "    Actual: const numArgsBetter: (...args: any[]) => number",
-    "  2/2 twoslash type assertions matched.",
+    "💥 ./src/test/inputs/issue-235.asciidoc:7:7-20: Failed type assertion for \`numArgsBetter\`
+  Expected: const numArgsBetter: (...args: any) => numberjsdklfjklsd
+    Actual: const numArgsBetter: (...args: any[]) => number",
+    "  1/2 twoslash type assertions matched.",
+    "const numArgsBad = (...args: any) => args.length;
+//    ^? const numArgsBad: (...args: any) => any
+const numArgsBetter = (...args: any[]) => args.length;
+//    ^? const numArgsBetter: (...args: any) => numberjsdklfjklsd",
+    "tsconfig options: {"strictNullChecks":true,"module":1}",
     "
 END #././src/test/inputs/issue-235.asciidoc:5 (--- ms)
 ",

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -472,6 +472,7 @@ describe('checker', () => {
     './src/test/inputs/check-jsonc.asciidoc',
     './src/test/inputs/node-output.asciidoc',
     './src/test/inputs/twoslash-assertion.asciidoc',
+    './src/test/inputs/issue-235.asciidoc',
   ])(
     'asciidoc checker snapshots %p',
     async inputFile => {

--- a/src/test/inputs/issue-235.asciidoc
+++ b/src/test/inputs/issue-235.asciidoc
@@ -1,0 +1,9 @@
+See https://github.com/danvk/literate-ts/issues/235
+
+[source,ts]
+----
+const numArgsBad = (...args: any) => args.length;
+//    ^? const numArgsBad: (...args: any) => any
+const numArgsBetter = (...args: any[]) => args.length;
+//    ^? const numArgsBetter: (...args: any) => numberjsdklfjklsd
+----

--- a/src/test/ts-checker.test.ts
+++ b/src/test/ts-checker.test.ts
@@ -540,6 +540,17 @@ describe('ts-checker', () => {
       const expected = 'const numArgsBetter: (...args: any) => numberjsdklfjklsd';
       expect(matchModuloWhitespace(actual, expected)).toBe(false);
     });
+
+    it('should see differences between object types', () => {
+      const expected = `const pharaoh: { start?: number | undefined; end?: number; name: string; title: string; }`;
+      const actual = `const pharaoh: {
+        start?: number | undefined;
+        end?: number | undefined;
+        name: string;
+        title: string;
+      }`;
+      expect(matchModuloWhitespace(actual, expected)).toBe(false);
+    });
   });
 
   describe('sortUnions', () => {

--- a/src/test/ts-checker.test.ts
+++ b/src/test/ts-checker.test.ts
@@ -534,6 +534,12 @@ describe('ts-checker', () => {
       const expected = `function fetchANumber( input: RequestInfo | URL, init?: RequestInit | undefined ): Promise<number>`;
       expect(matchModuloWhitespace(actual, expected)).toBe(true);
     });
+
+    it('should still see differences', () => {
+      const actual = 'const numArgsBetter: (...args: any[]) => number';
+      const expected = 'const numArgsBetter: (...args: any) => numberjsdklfjklsd';
+      expect(matchModuloWhitespace(actual, expected)).toBe(false);
+    });
   });
 
   describe('sortUnions', () => {

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -391,7 +391,7 @@ export function matchModuloWhitespace(actual: string, expected: string): boolean
   // TODO: it's much easier to normalize actual based on the displayParts
   //       This isn't 100% correct if a type has a space in it, e.g. type T = "string literal"
   const normalize = (input: string) => {
-    const isFunction = !!input.match(/^ *function /);
+    const isFunction = !!input.match(/^ *function /) || !!input.match(/=>/);
 
     let name: string;
     let type: string;

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -450,7 +450,7 @@ export function checkTwoslashAssertions(
       const {character: end} = source.getLineAndCharacterOfPosition(node.getEnd());
       fail(
         `Failed type assertion for \`${node.getText()}\`\n` +
-          `  Expected: ${assertion.type}\n` +
+          `  Expected: ${type}\n` +
           `    Actual: ${actual}`,
         {
           location: {
@@ -463,7 +463,7 @@ export function checkTwoslashAssertions(
       anyFailures = true;
     } else {
       log(`Twoslash type assertion match:`);
-      log(`  Expected: ${assertion.type}`);
+      log(`  Expected: ${type}`);
       log(`    Actual: ${actual}`);
       matchedAssertions++;
     }


### PR DESCRIPTION
Fixes #235 

Also fixed an even scarier issue with object types. I was ignoring basically everything because I misunderstood the behavior of `str.split(pat, N)`. It truncates, rather than putting all the rest of the string in the last group (as Python would).