### PR TITLE
Add example with top level await

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ See above for how to give directive to literate-ts in your source format.
   <dd>
     Set a tsconfig setting for the next code sample, e.g. `strictNullChecks=false`.
     These accumulate until the next `reset` directive. By default, literate-ts will
-    use whatever settings are in your `tsconfig.json` file.
+    use whatever settings are in your `tsconfig.json` file. If the setting expects an enum value (e.g. module, moduleResolution, target) then you need to write in the enum value, not the string. So `target=9`, not `target=ES2022`.
   </dd>
   <dt>verifier:check-js</dt>
   <dd>

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ See above for how to give directive to literate-ts in your source format.
   <dd>
     Set a tsconfig setting for the next code sample, e.g. `strictNullChecks=false`.
     These accumulate until the next `reset` directive. By default, literate-ts will
-    use whatever settings are in your `tsconfig.json` file. If the setting expects an enum value (e.g. module, moduleResolution, target) then you need to write in the enum value, not the string. So `target=9`, not `target=ES2022`.
+    use whatever settings are in your `tsconfig.json` file. If the setting expects an enum value (e.g. module, moduleResolution, target) then you need to write in the enum value, not the string. So `target=9`, not `target=ES2022`. See https://github.com/danvk/literate-ts/issues/249.
   </dd>
   <dt>verifier:check-js</dt>
   <dd>

--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -37,7 +37,7 @@ function process(
   let prependLines: number[] | null = null;
   let nextIsReplaced: string | null = null;
   let nodeModules: readonly string[] = [];
-  let tsOptions: {[key: string]: string | boolean} = {};
+  let tsOptions: {[key: string]: string | boolean | number} = {};
   let nextIsTSX = false;
   let nextShouldCheckJs = false;
   let targetFilename: string | null = null;
@@ -83,7 +83,14 @@ function process(
         skipRemaining = true;
       } else if (directive.startsWith('tsconfig:')) {
         const [key, value] = directive.split(':', 2)[1].split('=', 2);
-        tsOptions[key] = value === 'true' ? true : value === 'false' ? false : value;
+        tsOptions[key] =
+          value === 'true'
+            ? true
+            : value === 'false'
+              ? false
+              : isNaN(Number(value))
+                ? value
+                : Number(value);
       } else if (directive.startsWith('include-node-module:')) {
         const value = directive.split(':', 2)[1];
         nodeModules = nodeModules.concat([value]);

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -578,9 +578,9 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/top-level-await.a
     "---- BEGIN FILE ./src/test/inputs/top-level-await.asciidoc
 ",
     "Found 1 code samples in ./src/test/inputs/top-level-await.asciidoc",
-    "BEGIN #././src/test/inputs/top-level-await.asciidoc:5 (--filter top-level-await-5)
+    "BEGIN #././src/test/inputs/top-level-await.asciidoc:7 (--filter top-level-await-7)
 ",
-    "💥 ./src/test/inputs/top-level-await.asciidoc:12:18-23: Unexpected TypeScript error: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', or 'nodenext', and the 'target' option is set to 'es2017' or higher.",
+    "💥 ./src/test/inputs/top-level-await.asciidoc:14:18-23: Unexpected TypeScript error: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', or 'nodenext', and the 'target' option is set to 'es2017' or higher.",
     "declare function get(url: string): Promise<number>;
 export async function timeout(ms: number): Promise<never> {
     return new Promise((resolve, reject) => {
@@ -590,16 +590,16 @@ export async function timeout(ms: number): Promise<never> {
 
 const resource = await Promise.race([get('example.com'), timeout(500)]);
 //    ^? const resource: number",
-    "tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}",
+    "tsconfig options: {"strictNullChecks":true,"module":"es2022","esModuleInterop":true,"target":"es2017"}",
     "
-END #././src/test/inputs/top-level-await.asciidoc:5 (--- ms)
+END #././src/test/inputs/top-level-await.asciidoc:7 (--- ms)
 ",
     "---- END FILE ./src/test/inputs/top-level-await.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/top-level-await.asciidoc",
-    "1/1: ././src/test/inputs/top-level-await.asciidoc: 1/1 ././src/test/inputs/top-level-await.asciidoc:5",
+    "1/1: ././src/test/inputs/top-level-await.asciidoc: 1/1 ././src/test/inputs/top-level-await.asciidoc:7",
   ],
 }
 `;
@@ -1913,11 +1913,11 @@ export async function timeout(ms: number): Promise<never> {
 
 const resource = await Promise.race([get('example.com'), timeout(500)]);
 //    ^? const resource: number",
-    "descriptor": "./top-level-await.asciidoc:5",
-    "id": "top-level-await-5",
+    "descriptor": "./top-level-await.asciidoc:7",
+    "id": "top-level-await-7",
     "isTSX": false,
     "language": "ts",
-    "lineNumber": 4,
+    "lineNumber": 6,
     "nodeModules": [],
     "prefixes": [],
     "prefixesLength": 0,
@@ -1926,7 +1926,10 @@ const resource = await Promise.race([get('example.com'), timeout(500)]);
     "skip": false,
     "sourceFile": "top-level-await.asciidoc",
     "targetFilename": null,
-    "tsOptions": {},
+    "tsOptions": {
+      "module": "es2022",
+      "target": "es2017",
+    },
   },
 ]
 `;

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -578,28 +578,22 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/top-level-await.a
     "---- BEGIN FILE ./src/test/inputs/top-level-await.asciidoc
 ",
     "Found 1 code samples in ./src/test/inputs/top-level-await.asciidoc",
-    "BEGIN #././src/test/inputs/top-level-await.asciidoc:7 (--filter top-level-await-7)
+    "BEGIN #././src/test/inputs/top-level-await.asciidoc:8 (--filter top-level-await-8)
 ",
-    "💥 ./src/test/inputs/top-level-await.asciidoc:14:18-23: Unexpected TypeScript error: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', or 'nodenext', and the 'target' option is set to 'es2017' or higher.",
-    "declare function get(url: string): Promise<number>;
-export async function timeout(ms: number): Promise<never> {
-    return new Promise((resolve, reject) => {
-        setTimeout(reject, ms);
-    });
-}
-
-const resource = await Promise.race([get('example.com'), timeout(500)]);
-//    ^? const resource: number",
-    "tsconfig options: {"strictNullChecks":true,"module":"es2022","esModuleInterop":true,"target":"es2017"}",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: const resource: number",
+    "    Actual: const resource: number",
+    "  1/1 twoslash type assertions matched.",
     "
-END #././src/test/inputs/top-level-await.asciidoc:7 (--- ms)
+END #././src/test/inputs/top-level-await.asciidoc:8 (--- ms)
 ",
     "---- END FILE ./src/test/inputs/top-level-await.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/top-level-await.asciidoc",
-    "1/1: ././src/test/inputs/top-level-await.asciidoc: 1/1 ././src/test/inputs/top-level-await.asciidoc:7",
+    "1/1: ././src/test/inputs/top-level-await.asciidoc: 1/1 ././src/test/inputs/top-level-await.asciidoc:8",
   ],
 }
 `;
@@ -1913,11 +1907,11 @@ export async function timeout(ms: number): Promise<never> {
 
 const resource = await Promise.race([get('example.com'), timeout(500)]);
 //    ^? const resource: number",
-    "descriptor": "./top-level-await.asciidoc:7",
-    "id": "top-level-await-7",
+    "descriptor": "./top-level-await.asciidoc:8",
+    "id": "top-level-await-8",
     "isTSX": false,
     "language": "ts",
-    "lineNumber": 6,
+    "lineNumber": 7,
     "nodeModules": [],
     "prefixes": [],
     "prefixesLength": 0,
@@ -1927,8 +1921,9 @@ const resource = await Promise.race([get('example.com'), timeout(500)]);
     "sourceFile": "top-level-await.asciidoc",
     "targetFilename": null,
     "tsOptions": {
-      "module": "es2022",
-      "target": "es2017",
+      "module": 7,
+      "moduleResolution": 2,
+      "target": 4,
     },
   },
 ]

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -572,6 +572,38 @@ END #././src/test/inputs/program-listing.asciidoc:49 (--- ms)
 }
 `;
 
+exports[`checker asciidoc checker snapshots "./src/test/inputs/top-level-await.asciidoc": ./src/test/inputs/top-level-await.asciidoc 1`] = `
+{
+  "logs": [
+    "---- BEGIN FILE ./src/test/inputs/top-level-await.asciidoc
+",
+    "Found 1 code samples in ./src/test/inputs/top-level-await.asciidoc",
+    "BEGIN #././src/test/inputs/top-level-await.asciidoc:5 (--filter top-level-await-5)
+",
+    "💥 ./src/test/inputs/top-level-await.asciidoc:12:18-23: Unexpected TypeScript error: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', or 'nodenext', and the 'target' option is set to 'es2017' or higher.",
+    "declare function get(url: string): Promise<number>;
+export async function timeout(ms: number): Promise<never> {
+    return new Promise((resolve, reject) => {
+        setTimeout(reject, ms);
+    });
+}
+
+const resource = await Promise.race([get('example.com'), timeout(500)]);
+//    ^? const resource: number",
+    "tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}",
+    "
+END #././src/test/inputs/top-level-await.asciidoc:5 (--- ms)
+",
+    "---- END FILE ./src/test/inputs/top-level-await.asciidoc
+",
+  ],
+  "statuses": [
+    "1/1: ././src/test/inputs/top-level-await.asciidoc",
+    "1/1: ././src/test/inputs/top-level-await.asciidoc: 1/1 ././src/test/inputs/top-level-await.asciidoc:5",
+  ],
+}
+`;
+
 exports[`checker asciidoc checker snapshots "./src/test/inputs/twoslash-assertion.asciidoc": ./src/test/inputs/twoslash-assertion.asciidoc 1`] = `
 {
   "logs": [
@@ -1861,6 +1893,38 @@ exports[`extractSamples snapshot: skip 1`] = `
     "sectionHeader": null,
     "skip": true,
     "sourceFile": "skip.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+]
+`;
+
+exports[`extractSamples snapshot: top-level-await 1`] = `
+[
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "declare function get(url: string): Promise<number>;
+export async function timeout(ms: number): Promise<never> {
+    return new Promise((resolve, reject) => {
+        setTimeout(reject, ms);
+    });
+}
+
+const resource = await Promise.race([get('example.com'), timeout(500)]);
+//    ^? const resource: number",
+    "descriptor": "./top-level-await.asciidoc:5",
+    "id": "top-level-await-5",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 4,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "top-level-await.asciidoc",
     "targetFilename": null,
     "tsOptions": {},
   },

--- a/src/test/asciidoc.test.ts
+++ b/src/test/asciidoc.test.ts
@@ -480,6 +480,7 @@ describe('checker', () => {
     './src/test/inputs/node-output.asciidoc',
     './src/test/inputs/twoslash-assertion.asciidoc',
     './src/test/inputs/issue-235.asciidoc',
+    './src/test/inputs/top-level-await.asciidoc',
   ])(
     'asciidoc checker snapshots %p',
     async inputFile => {

--- a/src/test/inputs/top-level-await.asciidoc
+++ b/src/test/inputs/top-level-await.asciidoc
@@ -1,7 +1,8 @@
 This code sample uses top-level `await`:
 
-// verifier:tsconfig:module=es2022
-// verifier:tsconfig:target=es2017
+// verifier:tsconfig:moduleResolution=2
+// verifier:tsconfig:module=7
+// verifier:tsconfig:target=4
 [source,ts]
 ----
 declare function get(url: string): Promise<number>;

--- a/src/test/inputs/top-level-await.asciidoc
+++ b/src/test/inputs/top-level-await.asciidoc
@@ -1,5 +1,7 @@
 This code sample uses top-level `await`:
 
+// verifier:tsconfig:module=es2022
+// verifier:tsconfig:target=es2017
 [source,ts]
 ----
 declare function get(url: string): Promise<number>;

--- a/src/test/inputs/top-level-await.asciidoc
+++ b/src/test/inputs/top-level-await.asciidoc
@@ -1,0 +1,14 @@
+This code sample uses top-level `await`:
+
+[source,ts]
+----
+declare function get(url: string): Promise<number>;
+export async function timeout(ms: number): Promise<never> {
+    return new Promise((resolve, reject) => {
+        setTimeout(reject, ms);
+    });
+}
+
+const resource = await Promise.race([get('example.com'), timeout(500)]);
+//    ^? const resource: number
+----

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -6,7 +6,7 @@ import {Readable, Writable} from 'node:stream';
 
 import stableJsonStringify from 'fast-json-stable-stringify';
 import _ from 'lodash';
-import path, {resolve} from 'path';
+import path from 'path';
 import ts from 'typescript';
 
 import {log} from './logger.js';
@@ -703,11 +703,19 @@ async function uncachedCheckTs(
   const numLines = content.split('\n').length;
   const actualErrorsRaw: TypeScriptError[] = diagnostics
     .map(diagnostic => {
-      const {line, character} = diagnostic.file!.getLineAndCharacterOfPosition(diagnostic.start!);
+      let line, character;
+      if (diagnostic.file) {
+        const x = diagnostic.file!.getLineAndCharacterOfPosition(diagnostic.start!);
+        line = x.line;
+        character = x.character;
+      } else {
+        line = character = 0;
+      }
+      const end = character + (diagnostic.length ?? 0);
       return {
         line,
         start: character,
-        end: character + diagnostic.length!,
+        end,
         message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
       };
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "node16",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "Node16",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es2019", "dom"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
Fixes #230 

Turns out it was supported all along, but obscured due to #249 