### PR TITLE
Support "equivalent to" for values

### DIFF
--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -6,6 +6,7 @@ import {extractAsciidocSamples} from './asciidoc.js';
 import {extractMarkdownSamples} from './markdown.js';
 import {generateIdMetadata} from './metadata.js';
 import {stripComments} from 'jsonc-parser';
+import {dedent} from './utils.js';
 
 export interface Processor {
   /** Let the processor know about the current line number (0-based). */
@@ -300,6 +301,13 @@ const EQUIVALENT_RE = /\^\? type ([A-Za-z0-9_]+) = (.*)( \(equivalent to (.*)\))
 const EQUIVALENT_MULTILINE_RE =
   /\^\? type ([A-Za-z0-9_]+) = (.*)(\n\s*\/\/ +\(equivalent to (.*)\))$/m;
 
+const VALUE_EQUIVALENT_RE = /\^\? [^ ]+ ([A-Za-z0-9_]+): (.*)( \(equivalent to (.*)\))$/m;
+const VALUE_EQUIVALENT_MULTILINE_RE =
+  /\^\? [^ ]+ ([A-Za-z0-9_]+): (.*)(\n\s*\/\/ +\(equivalent to (.*)\))$/m;
+
+const RESOLVE_HELPER =
+  'type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};\n';
+
 /** Patch the code sample to test "equivalent to" types */
 export function addResolvedChecks(sample: CodeSample): CodeSample {
   const {content} = sample;
@@ -307,20 +315,34 @@ export function addResolvedChecks(sample: CodeSample): CodeSample {
     return sample;
   }
 
+  let synthName, type, equivClause, equivType;
   const m = EQUIVALENT_RE.exec(content) || EQUIVALENT_MULTILINE_RE.exec(content);
-  if (!m) {
-    return sample;
+  if (m) {
+    [, type, , equivClause, equivType] = m;
+    synthName = `Synth${type}`;
+  } else {
+    const mv = VALUE_EQUIVALENT_RE.exec(content) || VALUE_EQUIVALENT_MULTILINE_RE.exec(content);
+    if (mv) {
+      // would be nice to preserve indentation here
+      let varName;
+      [, varName, , equivClause, equivType] = mv;
+      synthName = 'Synth' + varName.charAt(0).toUpperCase() + varName.slice(1);
+      type = `typeof ${varName}`;
+    } else {
+      return sample;
+    }
   }
-
-  const [, typeName, _raw, equivClause, equivType] = m;
 
   // Strip the "equivalent to" bit, add Resolve<T> helper and secondary type assertion.
   // See https://github.com/danvk/literate-ts/issues/132 and
   // https://effectivetypescript.com/2022/02/25/gentips-4-display/
-  let newContent = content.replace(equivClause, '');
-  newContent += '\ntype Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};';
-  newContent += `\ntype Synth${typeName} = Resolve<${typeName}>;`;
-  newContent += `\n//   ^? type Synth${typeName} = ${equivType}\n`;
+  let newContent = content.replace(
+    equivClause,
+    dedent`\n
+    type ${synthName} = Resolve<${type}>;
+    //   ^? type ${synthName} = ${equivType}`,
+  );
+  newContent = RESOLVE_HELPER + newContent;
 
   return {
     ...sample,

--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -105,7 +105,7 @@ exports[`checker asciidoc checker snapshots "./src/test/inputs/equivalent.asciid
   "logs": [
     "---- BEGIN FILE ./src/test/inputs/equivalent.asciidoc
 ",
-    "Found 4 code samples in ./src/test/inputs/equivalent.asciidoc",
+    "Found 6 code samples in ./src/test/inputs/equivalent.asciidoc",
     "BEGIN #././src/test/inputs/equivalent.asciidoc:8 (--filter equivalent-8)
 ",
     "Code passed type checker.",
@@ -192,15 +192,67 @@ type SynthT2 = Resolve<T2>;
     "
 END #././src/test/inputs/equivalent.asciidoc:39 (--- ms)
 ",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:48 (--filter equivalent-48)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: type T = keyof Point",
+    "    Actual: type T = keyof Point",
+    "Twoslash type assertion match:",
+    "  Expected: let k: keyof Point",
+    "    Actual: let k: keyof Point",
+    "Twoslash type assertion match:",
+    "  Expected: type SynthK = "x" | "y"",
+    "    Actual: type SynthK = "x" | "y"",
+    "  3/3 twoslash type assertions matched.",
+    "
+END #././src/test/inputs/equivalent.asciidoc:48 (--- ms)
+",
+    "BEGIN #././src/test/inputs/equivalent.asciidoc:60 (--filter equivalent-60)
+",
+    "Code passed type checker.",
+    "Twoslash type assertion match:",
+    "  Expected: type T = keyof Point",
+    "    Actual: type T = keyof Point",
+    "Twoslash type assertion match:",
+    "  Expected: let k: keyof Point",
+    "    Actual: let k: keyof Point",
+    "💥 ./src/test/inputs/equivalent.asciidoc:67:6-12: Failed type assertion for \`SynthK\`
+  Expected: type SynthK = "x" | "y" | "z"
+    Actual: type SynthK = "x" | "y"",
+    "  2/3 twoslash type assertions matched.",
+    "interface Point {
+  x: number;
+  y: number;
+}
+
+type T = keyof Point;
+//   ^? type T = keyof Point
+function foo(pt: Point) {
+  let k: keyof Point;
+  for (k in pt) {
+    // ^? let k: keyof Point
+  }
+}
+type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
+type SynthK = Resolve<keyof Point>;
+//   ^? type SynthK = "x" | "y" | "z"
+",
+    "tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}",
+    "
+END #././src/test/inputs/equivalent.asciidoc:60 (--- ms)
+",
     "---- END FILE ./src/test/inputs/equivalent.asciidoc
 ",
   ],
   "statuses": [
     "1/1: ././src/test/inputs/equivalent.asciidoc",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 1/4 ././src/test/inputs/equivalent.asciidoc:8",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 2/4 ././src/test/inputs/equivalent.asciidoc:23",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 3/4 ././src/test/inputs/equivalent.asciidoc:31",
-    "1/1: ././src/test/inputs/equivalent.asciidoc: 4/4 ././src/test/inputs/equivalent.asciidoc:39",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 1/6 ././src/test/inputs/equivalent.asciidoc:8",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 2/6 ././src/test/inputs/equivalent.asciidoc:23",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 3/6 ././src/test/inputs/equivalent.asciidoc:31",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 4/6 ././src/test/inputs/equivalent.asciidoc:39",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 5/6 ././src/test/inputs/equivalent.asciidoc:48",
+    "1/1: ././src/test/inputs/equivalent.asciidoc: 6/6 ././src/test/inputs/equivalent.asciidoc:60",
   ],
 }
 `;
@@ -999,6 +1051,62 @@ type T = keyof Point;
     "isTSX": false,
     "language": "ts",
     "lineNumber": 38,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "equivalent-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "equivalent.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "function foo(pt: Point) {
+  let k: keyof Point;
+  for (k in pt) {
+    // ^? let k: keyof Point (equivalent to "x" | "y")
+  }
+}",
+    "descriptor": "./equivalent.asciidoc:48",
+    "id": "equivalent-48",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 47,
+    "nodeModules": [],
+    "prefixes": [
+      {
+        "id": "equivalent-8",
+      },
+    ],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "equivalent.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "function foo(pt: Point) {
+  let k: keyof Point;
+  for (k in pt) {
+    // ^? let k: keyof Point (equivalent to "x" | "y" | "z")
+  }
+}",
+    "descriptor": "./equivalent.asciidoc:60",
+    "id": "equivalent-60",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 59,
     "nodeModules": [],
     "prefixes": [
       {

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -456,15 +456,16 @@ describe('addResolvedChecks', () => {
     );
     expect(addResolvedChecks(sample[0]).content).toEqual(
       dedent`
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       interface Point {
         x: number;
         y: number;
       }
       type T = keyof Point;
       //   ^? type T = keyof Point
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type SynthT = Resolve<T>;
-      //   ^? type SynthT = "x" | "y"`,
+      //   ^? type SynthT = "x" | "y"
+      `,
     );
   });
 
@@ -506,15 +507,12 @@ describe('addResolvedChecks', () => {
     );
 
     expect(addResolvedChecks(sample[0]).content).toEqual(dedent`
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       interface Point {
         x: number;
         y: number;
       }
       type PointKeys = keyof Point;
       //   ^? type PointKeys = keyof Point
-      type SynthPointKeys = Resolve<PointKeys>;
-      //   ^? type SynthPointKeys = "x" | "y"
 
       function sortBy<K extends keyof T, T>(vals: T[], key: K): T[] {
         // ...
@@ -524,7 +522,11 @@ describe('addResolvedChecks', () => {
       sortBy(pts, 'y');  // OK, 'y' extends 'x'|'y'
       sortBy(pts, Math.random() < 0.5 ? 'x' : 'y');  // OK, 'x'|'y' extends 'x'|'y'
       sortBy(pts, 'z');
-               // ~~~ Type '"z"' is not assignable to parameter of type '"x" | "y"`);
+               // ~~~ Type '"z"' is not assignable to parameter of type '"x" | "y"
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
+      type SynthPointKeys = Resolve<PointKeys>;
+      //   ^? type SynthPointKeys = "x" | "y"
+      `);
   });
 
   it('should patch a type assertion split across lines', () => {
@@ -546,11 +548,12 @@ describe('addResolvedChecks', () => {
     );
 
     expect(addResolvedChecks(sample[0]).content).toEqual(dedent`
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type T2 = keyof Point;
       //   ^? type T2 = keyof Point
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type SynthT2 = Resolve<T2>;
-      //   ^? type SynthT2 = "x" | "y"`);
+      //   ^? type SynthT2 = "x" | "y"
+      `);
   });
 
   it('should patch a type assertion on a value', () => {
@@ -575,16 +578,16 @@ describe('addResolvedChecks', () => {
     );
 
     const actual = addResolvedChecks(sample[0]).content;
-    console.log(actual);
     expect(actual).toEqual(dedent`
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       function foo(pt: Point) {
         let k: keyof Point;
         for (k in pt) {
           // ^? let k: keyof Point
-      type SynthK = Resolve<typeof k>;
-      //   ^? type SynthK = "x" | "y"
         }
-      }`);
+      }
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
+      type SynthK = Resolve<keyof Point>;
+      //   ^? type SynthK = "x" | "y"
+      `);
   });
 });

--- a/src/test/code-sample.test.ts
+++ b/src/test/code-sample.test.ts
@@ -456,16 +456,15 @@ describe('addResolvedChecks', () => {
     );
     expect(addResolvedChecks(sample[0]).content).toEqual(
       dedent`
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       interface Point {
         x: number;
         y: number;
       }
       type T = keyof Point;
       //   ^? type T = keyof Point
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type SynthT = Resolve<T>;
-      //   ^? type SynthT = "x" | "y"
-      `,
+      //   ^? type SynthT = "x" | "y"`,
     );
   });
 
@@ -507,12 +506,15 @@ describe('addResolvedChecks', () => {
     );
 
     expect(addResolvedChecks(sample[0]).content).toEqual(dedent`
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       interface Point {
         x: number;
         y: number;
       }
       type PointKeys = keyof Point;
       //   ^? type PointKeys = keyof Point
+      type SynthPointKeys = Resolve<PointKeys>;
+      //   ^? type SynthPointKeys = "x" | "y"
 
       function sortBy<K extends keyof T, T>(vals: T[], key: K): T[] {
         // ...
@@ -522,11 +524,7 @@ describe('addResolvedChecks', () => {
       sortBy(pts, 'y');  // OK, 'y' extends 'x'|'y'
       sortBy(pts, Math.random() < 0.5 ? 'x' : 'y');  // OK, 'x'|'y' extends 'x'|'y'
       sortBy(pts, 'z');
-               // ~~~ Type '"z"' is not assignable to parameter of type '"x" | "y"
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
-      type SynthPointKeys = Resolve<PointKeys>;
-      //   ^? type SynthPointKeys = "x" | "y"
-      `);
+               // ~~~ Type '"z"' is not assignable to parameter of type '"x" | "y"`);
   });
 
   it('should patch a type assertion split across lines', () => {
@@ -548,15 +546,14 @@ describe('addResolvedChecks', () => {
     );
 
     expect(addResolvedChecks(sample[0]).content).toEqual(dedent`
+      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type T2 = keyof Point;
       //   ^? type T2 = keyof Point
-      type Resolve<Raw> = Raw extends Function ? Raw : {[K in keyof Raw]: Raw[K]};
       type SynthT2 = Resolve<T2>;
-      //   ^? type SynthT2 = "x" | "y"
-      `);
+      //   ^? type SynthT2 = "x" | "y"`);
   });
 
-  it.only('should patch a type assertion on a value', () => {
+  it('should patch a type assertion on a value', () => {
     const sample = applyPrefixes(
       extractSamples(
         dedent`

--- a/src/test/inputs/equivalent.asciidoc
+++ b/src/test/inputs/equivalent.asciidoc
@@ -40,3 +40,15 @@ type T2 = keyof Point;
 //   ^? type T2 = keyof Point
 //      (equivalent to "x" | "y" | "z")
 ----
+
+You can use the same pattern with values as well as types:
+
+[source,ts]
+----
+function foo(pt: Point) {
+  let k: keyof Point;
+  for (k in pt) {
+    // ^? let k: keyof Point (equivalent to "x" | "y")
+  }
+}
+----

--- a/src/test/inputs/equivalent.asciidoc
+++ b/src/test/inputs/equivalent.asciidoc
@@ -52,3 +52,15 @@ function foo(pt: Point) {
   }
 }
 ----
+
+This one should fail:
+
+[source,ts]
+----
+function foo(pt: Point) {
+  let k: keyof Point;
+  for (k in pt) {
+    // ^? let k: keyof Point (equivalent to "x" | "y" | "z")
+  }
+}
+----


### PR DESCRIPTION
Fixes #167 

Weirdly the `Resolve` helper only resolves types at the top level, not in functions:

```ts
interface Point {
  x: number;
  y: number;
}

type Resolve<Raw> = Raw extends Function ? Raw : { [K in keyof Raw]: Raw[K] };
function foo(pt: Point) {
  let k: keyof Point;
  for (k in pt) {
    // ^? let k: keyof Point
    type SynthK = Resolve<keyof Point>;
    //   ^? type SynthK = keyof Point
  }
}

type SynthT2 = Resolve<keyof Point>;
//   ^? type SynthT2 = "x" | "y"`);
```

This might be https://github.com/microsoft/TypeScript/issues/49852