### PR TITLE
fix: be stricter about continuation lines for twoslash

### DIFF
--- a/src/test/__snapshots__/asciidoc.test.ts.snap
+++ b/src/test/__snapshots__/asciidoc.test.ts.snap
@@ -1332,6 +1332,51 @@ exports[`extractSamples snapshot: multilinetype 1`] = `
     "targetFilename": null,
     "tsOptions": {},
   },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "const o = {x: 1, y: 2};
+//    ^? const o: {
+//         x: number;
+//         y: number;
+//       }",
+    "descriptor": "./multilinetype.asciidoc:25",
+    "id": "multilinetype-25",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 24,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "multilinetype.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
+  {
+    "auxiliaryFiles": [],
+    "checkJS": false,
+    "content": "const o = {x: 1, y: 2};
+//    ^? const o: { x: number; y: number; }
+//    this comment applies to the next line.
+const p = o;",
+    "descriptor": "./multilinetype.asciidoc:37",
+    "id": "multilinetype-37",
+    "isTSX": false,
+    "language": "ts",
+    "lineNumber": 36,
+    "nodeModules": [],
+    "prefixes": [],
+    "prefixesLength": 0,
+    "replacementId": undefined,
+    "sectionHeader": null,
+    "skip": false,
+    "sourceFile": "multilinetype.asciidoc",
+    "targetFilename": null,
+    "tsOptions": {},
+  },
 ]
 `;
 

--- a/src/test/inputs/multilinetype.asciidoc
+++ b/src/test/inputs/multilinetype.asciidoc
@@ -17,3 +17,25 @@ function addWithExtras(a: number, b: number) {
   return c;
 }
 ```
+
+This is a twoslash multiline assertion:
+
+[source,ts]
+----
+const o = {x: 1, y: 2};
+//    ^? const o: {
+//         x: number;
+//         y: number;
+//       }
+----
+
+
+This is not a multiline assertion:
+
+[source,ts]
+----
+const o = {x: 1, y: 2};
+//    ^? const o: { x: number; y: number; }
+//    this comment applies to the next line.
+const p = o;
+----

--- a/src/ts-checker.ts
+++ b/src/ts-checker.ts
@@ -225,7 +225,7 @@ export function extractTypeAssertions(source: ts.SourceFile): TypeScriptTypeAsse
         // line and char aren't strictly needed but they make the tests much more readable.
         assertions.push({position, type, ...lineAndChar});
         colForContinuation = character;
-        commentPrefixForContinuation = commentText.slice(0, twoslashOffset);
+        commentPrefixForContinuation = commentText.slice(0, twoslashOffset) + '   ';
       }
     }
   }


### PR DESCRIPTION
```ts
const a = {x: 1, y: 2};
//    ^? const a: { x: number; y: number; }
//    this is not a continuation line

const b = {x: 1, y: 2};
//    ^? const b: { x: number; y: number; }
//       this is a continuation line
```