### PR TITLE
feat: allow named values for tsconfig enums

### DIFF
--- a/src/code-sample.ts
+++ b/src/code-sample.ts
@@ -97,21 +97,16 @@ function process(
         skipRemaining = true;
       } else if (directive.startsWith('tsconfig:')) {
         const [key, value] = directive.split(':', 2)[1].split('=', 2);
-        let parsedValue;
         const enumKind = tsconfigToEnum[key];
-        if (enumKind) {
-          parsedValue = getEnumValue(key, enumKind, value);
-        } else {
-          parsedValue =
-            value === 'true'
-              ? true
-              : value === 'false'
-                ? false
-                : isNaN(Number(value))
-                  ? value
-                  : Number(value);
-        }
-        tsOptions[key] = parsedValue;
+        tsOptions[key] = enumKind
+          ? getEnumValue(key, enumKind, value)
+          : value === 'true'
+            ? true
+            : value === 'false'
+              ? false
+              : isNaN(Number(value))
+                ? value
+                : Number(value);
       } else if (directive.startsWith('include-node-module:')) {
         const value = directive.split(':', 2)[1];
         nodeModules = nodeModules.concat([value]);

--- a/src/test/inputs/check-emit.asciidoc
+++ b/src/test/inputs/check-emit.asciidoc
@@ -1,9 +1,9 @@
 With target=ES2021, numeric separators are preserved:
 
 // verifier:tsconfig:alwaysStrict=false
-// verifier:tsconfig:moduleResolution=2
-// verifier:tsconfig:module=99
-// verifier:tsconfig:target=8
+// verifier:tsconfig:moduleResolution=NodeJs
+// verifier:tsconfig:module=NodeNext
+// verifier:tsconfig:target=ES2021
 [[sep-es2021]]
 [source,ts]
 ----
@@ -20,7 +20,7 @@ const num = 1_234_567;
 
 With a lower target, however, they are not:
 
-// verifier:tsconfig:target=1
+// verifier:tsconfig:target=ES5
 [[sep-es5]]
 [source,ts]
 ----

--- a/src/test/inputs/check-emit.asciidoc
+++ b/src/test/inputs/check-emit.asciidoc
@@ -2,7 +2,7 @@ With target=ES2021, numeric separators are preserved:
 
 // verifier:tsconfig:alwaysStrict=false
 // verifier:tsconfig:moduleResolution=NodeJs
-// verifier:tsconfig:module=NodeNext
+// verifier:tsconfig:module=ESNext
 // verifier:tsconfig:target=ES2021
 [[sep-es2021]]
 [source,ts]

--- a/src/test/inputs/top-level-await.asciidoc
+++ b/src/test/inputs/top-level-await.asciidoc
@@ -1,8 +1,8 @@
 This code sample uses top-level `await`:
 
-// verifier:tsconfig:moduleResolution=2
-// verifier:tsconfig:module=7
-// verifier:tsconfig:target=4
+// verifier:tsconfig:moduleResolution=NodeJs
+// verifier:tsconfig:module=ES2022
+// verifier:tsconfig:target=ES2017
 [source,ts]
 ----
 declare function get(url: string): Promise<number>;

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,4 +1,6 @@
-import {dedent, matchAndExtract, reduceIndentation, sha256} from '../utils.js';
+import ts from 'typescript';
+
+import {dedent, getEnumValue, matchAndExtract, reduceIndentation, sha256} from '../utils.js';
 
 describe('utils', () => {
   test('matchAndExtract', () => {
@@ -30,5 +32,17 @@ describe('utils', () => {
       }
     }
   `);
+  });
+
+  test('getEnumValue', () => {
+    expect(getEnumValue('ScriptTarget', ts.ScriptTarget, 2)).toEqual(2);
+    expect(getEnumValue('ScriptTarget', ts.ScriptTarget, '2')).toEqual(2);
+    expect(getEnumValue('ScriptTarget', ts.ScriptTarget, 'ES2020')).toEqual(7);
+    expect(() => getEnumValue('ScriptTarget', ts.ScriptTarget, 'ES2007')).toThrow(
+      /ES2007 is not a valid ScriptTarget. Expected one of: 0, 1, 2, 3, 4, 5, 6, 7/,
+    );
+    expect(() => getEnumValue('ScriptTarget', ts.ScriptTarget, 2007)).toThrow(
+      /2007 is not a valid ScriptTarget. Expected one of: 0, 1, 2, 3, 4, 5, 6, 7/,
+    );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,6 +112,8 @@ export function getEnumValue<E extends EnumType<E>>(
 
   if (typeof str === 'number') {
     return str;
+  } else if (!isNaN(Number(str))) {
+    return Number(str);
   } else {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (enumType as any)[str];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,3 +95,25 @@ export const tuple = <Args extends unknown[]>(...args: Args): Args => args;
 export function reduceIndentation(src: string): string {
   return src.replace(/^(?:    )+/gm, spaces => _.repeat(' ', spaces.length / 2));
 }
+
+// See https://stackoverflow.com/a/50159864/388951
+export type EnumType<E> = Record<keyof E, number | string> & {[k: number]: string};
+
+export function getEnumValue<E extends EnumType<E>>(
+  enumName: string,
+  enumType: E,
+  str: string | number,
+): number {
+  if (!(str in enumType)) {
+    throw new Error(
+      `${str} is not a valid ${enumName}. Expected one of: ${Object.keys(enumType).join(', ')}`,
+    );
+  }
+
+  if (typeof str === 'number') {
+    return str;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (enumType as any)[str];
+  }
+}


### PR DESCRIPTION
Fixes #249 

Because "target: ES2017" is much clearer than "target: 4"!

It would be nice if this reported a failure rather than crashing.