### PR TITLE
chore: split off test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,11 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # Everything but the tests
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -44,11 +43,6 @@ jobs:
       - name: Prettier
         run: yarn format:check
 
-      - name: Test
-        run: yarn test --coverage
-
-      - uses: codecov/codecov-action@v3
-
       - name: Type Check
         run: yarn tsc
 
@@ -58,3 +52,26 @@ jobs:
 
       - name: Integration Test
         run: yarn check:asciidoc
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20.x
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Log Versions
+        run: yarn tsc --version && yarn jest --version
+
+      - name: Test
+        run: yarn test --coverage
+
+      - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Fixes #242 

The tests, particularly the baseline tests, are the slowest step on the CI workflow. Hopefully splitting them off will speed things up. It's harder to split off _just_ the baseline tests since then I'd have to merge code coverage data across builds.

This only winds up saving ~30s, but it's something!