### PR TITLE
feat: match error spans

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,10 +77,12 @@ jobs:
 
       - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
       - run: ls -l coverage
+      - run: ls coverage | grep -v ${{matrix.shard}}.json | xargs rm
+      - run: ls -l coverage
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts
-          path: coverage/*.json
+          path: coverage
 
   report-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,10 +75,13 @@ jobs:
 
         run: yarn test --shard=${{ matrix.shard }}/${{ strategy.job-total }} --coverage
 
-      - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
-      - run: ls -l coverage/*
-      - run: ls coverage/* | grep -v ${{matrix.shard}}.json | xargs rm
-      - run: ls -l coverage/*
+      - run: >-
+          ls -l coverage
+          mkdir coverage-tmp
+          mv coverage/coverage-final.json coverage-tmp/${{matrix.shard}}.json
+          mv coverage old-coverage
+          mv coverage-tmp coverage
+          ls -l coverage
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,12 +75,12 @@ jobs:
 
         run: yarn test --shard=${{ matrix.shard }}/${{ strategy.job-total }} --coverage
 
-      - run: >-
-          ls -l coverage
-          mkdir coverage-tmp
-          mv coverage/coverage-final.json coverage-tmp/${{matrix.shard}}.json
-          mv coverage old-coverage
-          mv coverage-tmp coverage
+      - run: >
+          ls -l coverage;
+          mkdir coverage-tmp;
+          mv coverage/coverage-final.json coverage-tmp/${{matrix.shard}}.json;
+          mv coverage old-coverage;
+          mv coverage-tmp coverage;
           ls -l coverage
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts
-          path: coverage/
+          path: coverage/*.json
 
   report-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,9 +76,9 @@ jobs:
         run: yarn test --shard=${{ matrix.shard }}/${{ strategy.job-total }} --coverage
 
       - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
-      - run: ls -l coverage
-      - run: ls coverage | grep -v ${{matrix.shard}}.json | xargs rm
-      - run: ls -l coverage
+      - run: ls -l coverage/*
+      - run: ls coverage/* | grep -v ${{matrix.shard}}.json | xargs rm
+      - run: ls -l coverage/*
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,17 +75,13 @@ jobs:
 
         run: yarn test --shard=${{ matrix.shard }}/${{ strategy.job-total }} --coverage
 
-      - run: >
-          ls -l coverage;
-          mkdir coverage-tmp;
-          mv coverage/coverage-final.json coverage-tmp/${{matrix.shard}}.json;
-          mv coverage old-coverage;
-          mv coverage-tmp coverage;
-          ls -l coverage
+      - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
+
+      # https://github.com/actions/download-artifact?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts
-          path: coverage
+          name: coverage-artifacts-${{ matrix.shard }}
+          path: coverage/
 
   report-coverage:
     runs-on: ubuntu-latest
@@ -94,8 +90,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-artifacts
           path: coverage
+          pattern: coverage-artifacts-*
+          merge-multiple: true
+      - run: ls -l coverage
       - name: Merge Code Coverage
         run: npx nyc merge coverage/ merged-output/merged-coverage.json
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
         run: yarn test --shard=${{ matrix.shard }}/${{ strategy.job-total }} --coverage
 
       - run: mv coverage/coverage-final.json coverage/${{matrix.shard}}.json
+      - run: ls -l coverage
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts

--- a/src/test/baselines/error-start-of-line.asciidoc.extract.yaml
+++ b/src/test/baselines/error-start-of-line.asciidoc.extract.yaml
@@ -60,3 +60,24 @@
   skip: false
   auxiliaryFiles: []
   inCommentBlock: false
+- descriptor: ./error-start-of-line.asciidoc:34
+  id: error-start-of-line-34
+  sectionHeader: null
+  language: ts
+  content: |-
+    {
+      longname = 12;
+      // ~~~~~ Cannot find name 'longname'.
+    }
+  prefixes: []
+  nodeModules: []
+  isTSX: false
+  checkJS: false
+  sourceFile: error-start-of-line.asciidoc
+  lineNumber: 33
+  targetFilename: null
+  tsOptions: {}
+  prefixesLength: 0
+  skip: false
+  auxiliaryFiles: []
+  inCommentBlock: false

--- a/src/test/baselines/error-start-of-line.asciidoc.extract.yaml
+++ b/src/test/baselines/error-start-of-line.asciidoc.extract.yaml
@@ -17,3 +17,46 @@
   skip: false
   auxiliaryFiles: []
   inCommentBlock: false
+- descriptor: ./error-start-of-line.asciidoc:13
+  id: error-start-of-line-13
+  sectionHeader: null
+  language: ts
+  content: |-
+    {
+      longname = 12;
+      // Error: Cannot find name 'longname'.
+    }
+  prefixes: []
+  nodeModules: []
+  isTSX: false
+  checkJS: false
+  sourceFile: error-start-of-line.asciidoc
+  lineNumber: 12
+  targetFilename: null
+  tsOptions: {}
+  prefixesLength: 0
+  skip: false
+  auxiliaryFiles: []
+  inCommentBlock: false
+- descriptor: ./error-start-of-line.asciidoc:23
+  id: error-start-of-line-23
+  sectionHeader: null
+  language: ts
+  content: |-
+    console.log(x);
+    // Error: Cannot find name 'x'.
+
+    console.log(x);
+    //          ~ Cannot find name 'x'.
+  prefixes: []
+  nodeModules: []
+  isTSX: false
+  checkJS: false
+  sourceFile: error-start-of-line.asciidoc
+  lineNumber: 22
+  targetFilename: null
+  tsOptions: {}
+  prefixesLength: 0
+  skip: false
+  auxiliaryFiles: []
+  inCommentBlock: false

--- a/src/test/baselines/error-start-of-line.asciidoc.extract.yaml
+++ b/src/test/baselines/error-start-of-line.asciidoc.extract.yaml
@@ -60,24 +60,3 @@
   skip: false
   auxiliaryFiles: []
   inCommentBlock: false
-- descriptor: ./error-start-of-line.asciidoc:34
-  id: error-start-of-line-34
-  sectionHeader: null
-  language: ts
-  content: |-
-    {
-      longname = 12;
-      // ~~~~~ Cannot find name 'longname'.
-    }
-  prefixes: []
-  nodeModules: []
-  isTSX: false
-  checkJS: false
-  sourceFile: error-start-of-line.asciidoc
-  lineNumber: 33
-  targetFilename: null
-  tsOptions: {}
-  prefixesLength: 0
-  skip: false
-  auxiliaryFiles: []
-  inCommentBlock: false

--- a/src/test/baselines/error-start-of-line.log.txt
+++ b/src/test/baselines/error-start-of-line.log.txt
@@ -1,6 +1,6 @@
 ---- BEGIN FILE ./src/test/inputs/error-start-of-line.asciidoc
 
-Found 3 code samples in ./src/test/inputs/error-start-of-line.asciidoc
+Found 4 code samples in ./src/test/inputs/error-start-of-line.asciidoc
 BEGIN #././src/test/inputs/error-start-of-line.asciidoc:5 (--filter error-start-of-line-5)
 
 matched errors:
@@ -38,6 +38,17 @@ console.log(x);
 tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}
 
 END #././src/test/inputs/error-start-of-line.asciidoc:23 (--- ms)
+
+BEGIN #././src/test/inputs/error-start-of-line.asciidoc:34 (--filter error-start-of-line-34)
+
+matched errors:
+  expected: Cannot find name 'longname'.
+    actual: Cannot find name 'longname'.
+  mismatched error span: start: -3
+  error messages match: perfect
+Matched 1/1 errors.
+
+END #././src/test/inputs/error-start-of-line.asciidoc:34 (--- ms)
 
 ---- END FILE ./src/test/inputs/error-start-of-line.asciidoc
 

--- a/src/test/baselines/error-start-of-line.log.txt
+++ b/src/test/baselines/error-start-of-line.log.txt
@@ -1,6 +1,6 @@
 ---- BEGIN FILE ./src/test/inputs/error-start-of-line.asciidoc
 
-Found 4 code samples in ./src/test/inputs/error-start-of-line.asciidoc
+Found 3 code samples in ./src/test/inputs/error-start-of-line.asciidoc
 BEGIN #././src/test/inputs/error-start-of-line.asciidoc:5 (--filter error-start-of-line-5)
 
 matched errors:
@@ -38,17 +38,6 @@ console.log(x);
 tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}
 
 END #././src/test/inputs/error-start-of-line.asciidoc:23 (--- ms)
-
-BEGIN #././src/test/inputs/error-start-of-line.asciidoc:34 (--filter error-start-of-line-34)
-
-matched errors:
-  expected: Cannot find name 'longname'.
-    actual: Cannot find name 'longname'.
-  mismatched error span: start: -3
-  error messages match: perfect
-Matched 1/1 errors.
-
-END #././src/test/inputs/error-start-of-line.asciidoc:34 (--- ms)
 
 ---- END FILE ./src/test/inputs/error-start-of-line.asciidoc
 

--- a/src/test/baselines/error-start-of-line.log.txt
+++ b/src/test/baselines/error-start-of-line.log.txt
@@ -1,6 +1,6 @@
 ---- BEGIN FILE ./src/test/inputs/error-start-of-line.asciidoc
 
-Found 1 code samples in ./src/test/inputs/error-start-of-line.asciidoc
+Found 3 code samples in ./src/test/inputs/error-start-of-line.asciidoc
 BEGIN #././src/test/inputs/error-start-of-line.asciidoc:5 (--filter error-start-of-line-5)
 
 matched errors:
@@ -10,6 +10,34 @@ matched errors:
 Matched 1/1 errors.
 
 END #././src/test/inputs/error-start-of-line.asciidoc:5 (--- ms)
+
+BEGIN #././src/test/inputs/error-start-of-line.asciidoc:13 (--filter error-start-of-line-13)
+
+matched errors:
+  expected: Cannot find name 'longname'.
+    actual: Cannot find name 'longname'.
+  error messages match: perfect
+Matched 1/1 errors.
+
+END #././src/test/inputs/error-start-of-line.asciidoc:13 (--- ms)
+
+BEGIN #././src/test/inputs/error-start-of-line.asciidoc:23 (--filter error-start-of-line-23)
+
+💥 ./src/test/inputs/error-start-of-line.asciidoc:23:13-14: Unexpected TypeScript error: Cannot find name 'x'.
+matched errors:
+  expected: Cannot find name 'x'.
+    actual: Cannot find name 'x'.
+  error messages match: perfect
+💥 ./src/test/inputs/error-start-of-line.asciidoc:23:1-2: Expected TypeScript error was not produced: Cannot find name 'x'.
+Matched 1/2 errors.
+console.log(x);
+// Error: Cannot find name 'x'.
+
+console.log(x);
+//          ~ Cannot find name 'x'.
+tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}
+
+END #././src/test/inputs/error-start-of-line.asciidoc:23 (--- ms)
 
 ---- END FILE ./src/test/inputs/error-start-of-line.asciidoc
 

--- a/src/test/baselines/error-start-of-line.status.txt
+++ b/src/test/baselines/error-start-of-line.status.txt
@@ -1,4 +1,5 @@
 1/1: ././src/test/inputs/error-start-of-line.asciidoc
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 1/3 ././src/test/inputs/error-start-of-line.asciidoc:5
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 2/3 ././src/test/inputs/error-start-of-line.asciidoc:13
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 3/3 ././src/test/inputs/error-start-of-line.asciidoc:23
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 1/4 ././src/test/inputs/error-start-of-line.asciidoc:5
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 2/4 ././src/test/inputs/error-start-of-line.asciidoc:13
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 3/4 ././src/test/inputs/error-start-of-line.asciidoc:23
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 4/4 ././src/test/inputs/error-start-of-line.asciidoc:34

--- a/src/test/baselines/error-start-of-line.status.txt
+++ b/src/test/baselines/error-start-of-line.status.txt
@@ -1,5 +1,4 @@
 1/1: ././src/test/inputs/error-start-of-line.asciidoc
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 1/4 ././src/test/inputs/error-start-of-line.asciidoc:5
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 2/4 ././src/test/inputs/error-start-of-line.asciidoc:13
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 3/4 ././src/test/inputs/error-start-of-line.asciidoc:23
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 4/4 ././src/test/inputs/error-start-of-line.asciidoc:34
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 1/3 ././src/test/inputs/error-start-of-line.asciidoc:5
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 2/3 ././src/test/inputs/error-start-of-line.asciidoc:13
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 3/3 ././src/test/inputs/error-start-of-line.asciidoc:23

--- a/src/test/baselines/error-start-of-line.status.txt
+++ b/src/test/baselines/error-start-of-line.status.txt
@@ -1,2 +1,4 @@
 1/1: ././src/test/inputs/error-start-of-line.asciidoc
-1/1: ././src/test/inputs/error-start-of-line.asciidoc: 1/1 ././src/test/inputs/error-start-of-line.asciidoc:5
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 1/3 ././src/test/inputs/error-start-of-line.asciidoc:5
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 2/3 ././src/test/inputs/error-start-of-line.asciidoc:13
+1/1: ././src/test/inputs/error-start-of-line.asciidoc: 3/3 ././src/test/inputs/error-start-of-line.asciidoc:23

--- a/src/test/baselines/unaligned-error.asciidoc.extract.yaml
+++ b/src/test/baselines/unaligned-error.asciidoc.extract.yaml
@@ -4,7 +4,8 @@
   language: ts
   content: |-
     function foo(): number {
-      //               ~~~~~~ A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+      //               ~~~~~~ A function whose declared type is neither
+      //                      'undefined', 'void', nor 'any' must return a value.
       console.log('not gonna return!');
     }
   prefixes: []

--- a/src/test/baselines/unaligned-error.asciidoc.extract.yaml
+++ b/src/test/baselines/unaligned-error.asciidoc.extract.yaml
@@ -20,3 +20,24 @@
   skip: false
   auxiliaryFiles: []
   inCommentBlock: false
+- descriptor: ./unaligned-error.asciidoc:16
+  id: unaligned-error-16
+  sectionHeader: null
+  language: ts
+  content: |-
+    {
+      longname = 12;
+      // ~~~~~ Cannot find name 'longname'.
+    }
+  prefixes: []
+  nodeModules: []
+  isTSX: false
+  checkJS: false
+  sourceFile: unaligned-error.asciidoc
+  lineNumber: 15
+  targetFilename: null
+  tsOptions: {}
+  prefixesLength: 0
+  skip: false
+  auxiliaryFiles: []
+  inCommentBlock: false

--- a/src/test/baselines/unaligned-error.asciidoc.extract.yaml
+++ b/src/test/baselines/unaligned-error.asciidoc.extract.yaml
@@ -1,0 +1,21 @@
+- descriptor: ./unaligned-error.asciidoc:5
+  id: unaligned-error-5
+  sectionHeader: null
+  language: ts
+  content: |-
+    function foo(): number {
+      //               ~~~~~~ A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+      console.log('not gonna return!');
+    }
+  prefixes: []
+  nodeModules: []
+  isTSX: false
+  checkJS: false
+  sourceFile: unaligned-error.asciidoc
+  lineNumber: 4
+  targetFilename: null
+  tsOptions: {}
+  prefixesLength: 0
+  skip: false
+  auxiliaryFiles: []
+  inCommentBlock: false

--- a/src/test/baselines/unaligned-error.log.txt
+++ b/src/test/baselines/unaligned-error.log.txt
@@ -7,6 +7,7 @@ matched errors:
   expected: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
     actual: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
   mismatched error span: start: -3, end: -3
+💥 ./src/test/inputs/unaligned-error.asciidoc:5:17-23: error span mismatch: end: -3
   error messages match: perfect
 Matched 1/1 errors.
 💥 ./src/test/inputs/unaligned-error.asciidoc:5:10-13: Failed type assertion for `foo`
@@ -14,11 +15,11 @@ Matched 1/1 errors.
     Actual: () => number
   0/1 type assertions matched.
 function foo(): number {
-  //               ~~~~~~ A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+  //               ~~~~~~ A function whose declared type is neither
+  //                      'undefined', 'void', nor 'any' must return a value.
   console.log('not gonna return!');
 }
 tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}
-💥 ./src/test/inputs/unaligned-error.asciidoc:6:101-120: Line too long: 119 > 100
 
 END #././src/test/inputs/unaligned-error.asciidoc:5 (--- ms)
 

--- a/src/test/baselines/unaligned-error.log.txt
+++ b/src/test/baselines/unaligned-error.log.txt
@@ -1,6 +1,6 @@
 ---- BEGIN FILE ./src/test/inputs/unaligned-error.asciidoc
 
-Found 1 code samples in ./src/test/inputs/unaligned-error.asciidoc
+Found 2 code samples in ./src/test/inputs/unaligned-error.asciidoc
 BEGIN #././src/test/inputs/unaligned-error.asciidoc:5 (--filter unaligned-error-5)
 
 matched errors:
@@ -22,6 +22,17 @@ function foo(): number {
 tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}
 
 END #././src/test/inputs/unaligned-error.asciidoc:5 (--- ms)
+
+BEGIN #././src/test/inputs/unaligned-error.asciidoc:16 (--filter unaligned-error-16)
+
+matched errors:
+  expected: Cannot find name 'longname'.
+    actual: Cannot find name 'longname'.
+  mismatched error span: start: -3
+  error messages match: perfect
+Matched 1/1 errors.
+
+END #././src/test/inputs/unaligned-error.asciidoc:16 (--- ms)
 
 ---- END FILE ./src/test/inputs/unaligned-error.asciidoc
 

--- a/src/test/baselines/unaligned-error.log.txt
+++ b/src/test/baselines/unaligned-error.log.txt
@@ -1,0 +1,26 @@
+---- BEGIN FILE ./src/test/inputs/unaligned-error.asciidoc
+
+Found 1 code samples in ./src/test/inputs/unaligned-error.asciidoc
+BEGIN #././src/test/inputs/unaligned-error.asciidoc:5 (--filter unaligned-error-5)
+
+matched errors:
+  expected: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+    actual: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+  mismatched error span: start: -3, end: -3
+  error messages match: perfect
+Matched 1/1 errors.
+💥 ./src/test/inputs/unaligned-error.asciidoc:5:10-13: Failed type assertion for `foo`
+  Expected: neither 'undefined', 'void', nor 'any' must return a value.
+    Actual: () => number
+  0/1 type assertions matched.
+function foo(): number {
+  //               ~~~~~~ A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+  console.log('not gonna return!');
+}
+tsconfig options: {"strictNullChecks":true,"module":1,"esModuleInterop":true}
+💥 ./src/test/inputs/unaligned-error.asciidoc:6:101-120: Line too long: 119 > 100
+
+END #././src/test/inputs/unaligned-error.asciidoc:5 (--- ms)
+
+---- END FILE ./src/test/inputs/unaligned-error.asciidoc
+

--- a/src/test/baselines/unaligned-error.status.txt
+++ b/src/test/baselines/unaligned-error.status.txt
@@ -1,0 +1,2 @@
+1/1: ././src/test/inputs/unaligned-error.asciidoc
+1/1: ././src/test/inputs/unaligned-error.asciidoc: 1/1 ././src/test/inputs/unaligned-error.asciidoc:5

--- a/src/test/baselines/unaligned-error.status.txt
+++ b/src/test/baselines/unaligned-error.status.txt
@@ -1,2 +1,3 @@
 1/1: ././src/test/inputs/unaligned-error.asciidoc
-1/1: ././src/test/inputs/unaligned-error.asciidoc: 1/1 ././src/test/inputs/unaligned-error.asciidoc:5
+1/1: ././src/test/inputs/unaligned-error.asciidoc: 1/2 ././src/test/inputs/unaligned-error.asciidoc:5
+1/1: ././src/test/inputs/unaligned-error.asciidoc: 2/2 ././src/test/inputs/unaligned-error.asciidoc:16

--- a/src/test/checker-logic.ts
+++ b/src/test/checker-logic.ts
@@ -24,6 +24,7 @@ const ALL_TESTS = [
   './src/test/inputs/error-start-of-line.asciidoc',
   './src/test/inputs/check-emit.asciidoc',
   './src/test/inputs/long-lines.asciidoc',
+  './src/test/inputs/unaligned-error.asciidoc',
 ];
 
 export function testsForShard(shard: number, total: number) {

--- a/src/test/checker.e2e.0.test.ts
+++ b/src/test/checker.e2e.0.test.ts
@@ -1,3 +1,3 @@
-import {checkerTest, testsForShard} from './checker-logic.js';
+import {checkerTest} from './checker-logic.js';
 
 checkerTest(0, 3);

--- a/src/test/inputs/error-start-of-line.asciidoc
+++ b/src/test/inputs/error-start-of-line.asciidoc
@@ -26,3 +26,13 @@ console.log(x);
 console.log(x);
 //          ~ Cannot find name 'x'.
 ----
+
+There is some wiggle room in error span matching at the start of a line. This is considered OK even though the span match isn't precise:
+
+[source,ts]
+----
+{
+  longname = 12;
+  // ~~~~~ Cannot find name 'longname'.
+}
+----

--- a/src/test/inputs/error-start-of-line.asciidoc
+++ b/src/test/inputs/error-start-of-line.asciidoc
@@ -26,13 +26,3 @@ console.log(x);
 console.log(x);
 //          ~ Cannot find name 'x'.
 ----
-
-There is some wiggle room in error span matching at the start of a line. This is considered OK even though the span match isn't precise:
-
-[source,ts]
-----
-{
-  longname = 12;
-  // ~~~~~ Cannot find name 'longname'.
-}
-----

--- a/src/test/inputs/error-start-of-line.asciidoc
+++ b/src/test/inputs/error-start-of-line.asciidoc
@@ -5,3 +5,24 @@ This code sample has an error at the very start of the line. It's awkward to put
 x = 12;
 // Error: Cannot find name 'x'.
 ----
+
+This also works for indented code:
+
+[source,ts]
+----
+{
+  longname = 12;
+  // Error: Cannot find name 'longname'.
+}
+----
+
+If the error is not at the start of the line, a mismatch will be reported:
+
+[source,ts]
+----
+console.log(x);
+// Error: Cannot find name 'x'.
+
+console.log(x);
+//          ~ Cannot find name 'x'.
+----

--- a/src/test/inputs/unaligned-error.asciidoc
+++ b/src/test/inputs/unaligned-error.asciidoc
@@ -1,0 +1,10 @@
+The indicated error span in this snippet overlaps the true one, but it's not a subset of it:
+
+[source,ts]
+----
+function foo(): number {
+  //               ~~~~~~ A function whose declared type is neither
+  //                      'undefined', 'void', nor 'any' must return a value.
+  console.log('not gonna return!');
+}
+----

--- a/src/test/inputs/unaligned-error.asciidoc
+++ b/src/test/inputs/unaligned-error.asciidoc
@@ -8,3 +8,13 @@ function foo(): number {
   console.log('not gonna return!');
 }
 ----
+
+There is some wiggle room in error span matching at the start of a line. This is considered OK even though the span match isn't precise:
+
+[source,ts]
+----
+{
+  longname = 12;
+  // ~~~~~ Cannot find name 'longname'.
+}
+----


### PR DESCRIPTION
This turned up a few minor typos in Effective TypeScript as well as places where tsc reports different error spans now than it did when I first tested the code samples. There's a bit of wiggle room in what we consider an error to allow patterns like this at the start of a line:

```ts
{
  longname = 12;
  // ~~~~~ Cannot find name 'longname'.
}
```

This includes some unrelated changes to fix coverage merging, which broke because of #286