### PR TITLE
chore: pass token explicitly to codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,3 +97,5 @@ jobs:
       - name: Merge Code Coverage
         run: npx nyc merge coverage/ merged-output/merged-coverage.json
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This is required as of codecov-action@v4, see #287 